### PR TITLE
f/config_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+.fotingo

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ An example file might look like this:
     
 Right now this file will store the username and password to your JIRA account in plaintext. I'm working on 
 improving that.
+
+### Local configuration files
+
+You can create local configuration files to your project. Just create a `.fotingo` file inside your project root folder.
+This file, needs to be in JSON format as well. If such file exist, any missing configuration will be added to this file instead.
+You can also overwrite global configuration in this file. An example config file may just be:
+
+    {
+      "github": {
+        "owner": "another-github-username"
+      }
+    }
     
 ## Usage
 
@@ -156,9 +168,9 @@ There are still tons of things that I would like to do to improve this tool:
 * Allow changes to the configuration via the CLI.
 * Switch from promises to generators or monads.
 * Use JIRA OAuth instead of Basic authentication.
-* Support multiple github owners (instead of having it globally in the config)
 * Add support to assign and add labels to pull requests.
 * Rebase current branch onto master. This may be tricky if there are conflicts.
+* Lookup config file in parent folders.
 
 ## Contributing 
 

--- a/lib/config/config-file-path.js
+++ b/lib/config/config-file-path.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.localConfigFilePath = exports.globalConfigFilePath = exports.CONFIG_FILE_NAME = undefined;
 
 var _path = require('path');
 
@@ -14,6 +15,7 @@ var _package2 = _interopRequireDefault(_package);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var CONFIG_FILE_NAME = '.' + _package2['default'].name;
+var CONFIG_FILE_NAME = exports.CONFIG_FILE_NAME = '.' + _package2['default'].name;
 
-exports['default'] = _path2['default'].resolve(process.env.HOME || process.env.USERPROFILE, CONFIG_FILE_NAME);
+var globalConfigFilePath = exports.globalConfigFilePath = _path2['default'].resolve(process.env.HOME || process.env.USERPROFILE, CONFIG_FILE_NAME);
+var localConfigFilePath = exports.localConfigFilePath = _path2['default'].resolve(process.cwd(), CONFIG_FILE_NAME);

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -48,8 +48,8 @@ var data = {
     return isJiraLoggedIn;
   }(),
   update: _ramda2['default'].curryN(2, function (path, value) {
-    config = _ramda2['default'].set(_ramda2['default'].lensPath(path), value)(config);
-    (0, _writeConfigFile2['default'])(config);
+    config = _ramda2['default'].set(_ramda2['default'].lensPath(path), value, config);
+    (0, _writeConfigFile2['default'])(config.local ? _ramda2['default'].set(_ramda2['default'].lensPath(path), value, {}) : config, config.local);
     return value;
   }),
   get: function () {

--- a/lib/config/read-config-file.js
+++ b/lib/config/read-config-file.js
@@ -14,8 +14,6 @@ var _ramda2 = _interopRequireDefault(_ramda);
 
 var _configFilePath = require('./config-file-path');
 
-var _configFilePath2 = _interopRequireDefault(_configFilePath);
-
 var _error = require('../error');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -23,17 +21,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 var createEmptyConfigFile = _ramda2['default'].curryN(3, _fs2['default'].writeFileSync)(_ramda2['default'].__, _ramda2['default'].__, 'utf8');
 var readConfigFile = _ramda2['default'].curryN(2, _ramda2['default'].compose(JSON.parse, _fs2['default'].readFileSync))(_ramda2['default'].__, 'utf8');
 
-// export default R.compose(JSON.parse, R.tryCatch(readUtf8File, curriedWriteFileSync, {}))(filePath);
+var getGlobalConfig = _ramda2['default'].tryCatch(_ramda2['default'].compose(readConfigFile, _ramda2['default'].always(_configFilePath.globalConfigFilePath)), _ramda2['default'].ifElse(_ramda2['default'].propEq('code', 'ENOENT'), _ramda2['default'].converge(_ramda2['default'].identity, [_ramda2['default'].nthArg(1), _ramda2['default'].compose(createEmptyConfigFile(_configFilePath.globalConfigFilePath), function (defaults) {
+  return JSON.stringify(defaults, null, 2);
+}, _ramda2['default'].nthArg(1))]), function () {
+  return (0, _error.handleError)(new _error.ControlledError(_error.errors.config.malformedFile));
+}));
 
+var getLocalConfig = _ramda2['default'].tryCatch(_ramda2['default'].compose(_ramda2['default'].set(_ramda2['default'].lensProp('local'), true), readConfigFile, _ramda2['default'].always(_configFilePath.localConfigFilePath)), _ramda2['default'].ifElse(_ramda2['default'].propEq('code', 'ENOENT'), _ramda2['default'].always({}), function () {
+  return (0, _error.handleError)(new _error.ControlledError(_error.errors.config.malformedFile));
+}));
 
-exports['default'] = function (defaults) {
-  try {
-    return readConfigFile(_configFilePath2['default']);
-  } catch (e) {
-    if (e.code && e.code === 'ENOENT') {
-      createEmptyConfigFile(_configFilePath2['default'], JSON.stringify(defaults, null, 2));
-      return defaults;
-    }
-    return (0, _error.handleError)(new _error.ControlledError(_error.errors.config.malformedFile));
-  }
-};
+exports['default'] = _ramda2['default'].converge(_ramda2['default'].mergeWith(_ramda2['default'].ifElse(_ramda2['default'].is(Object), _ramda2['default'].merge, _ramda2['default'].nthArg(1))), [getGlobalConfig, getLocalConfig]);

--- a/lib/config/write-config-file.js
+++ b/lib/config/write-config-file.js
@@ -10,10 +10,9 @@ var _fs2 = _interopRequireDefault(_fs);
 
 var _configFilePath = require('./config-file-path');
 
-var _configFilePath2 = _interopRequireDefault(_configFilePath);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 exports['default'] = function (data) {
-  return _fs2['default'].writeFileSync(_configFilePath2['default'], JSON.stringify(data, null, 2), { encoding: 'utf8', flag: 'w' });
+  var local = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+  return _fs2['default'].writeFileSync(local ? _configFilePath.localConfigFilePath : _configFilePath.globalConfigFilePath, JSON.stringify(data, null, 2), { encoding: 'utf8', flag: 'w' });
 };

--- a/src/config/config-file-path.js
+++ b/src/config/config-file-path.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import app from '../../package.json';
-const CONFIG_FILE_NAME = `.${app.name}`;
+export const CONFIG_FILE_NAME = `.${app.name}`;
 
-export default path.resolve(process.env.HOME || process.env.USERPROFILE, CONFIG_FILE_NAME);
+export const globalConfigFilePath = path.resolve(process.env.HOME || process.env.USERPROFILE, CONFIG_FILE_NAME);
+export const localConfigFilePath = path.resolve(process.cwd(), CONFIG_FILE_NAME);

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -23,8 +23,11 @@ const data = {
     R.isNil(data.get(['jira', 'user', 'login']))
   )),
   update: R.curryN(2, (path, value) => {
-    config = R.set(R.lensPath(path), value)(config);
-    writeConfigFile(config);
+    config = R.set(R.lensPath(path), value, config);
+    writeConfigFile(
+      config.local ? R.set(R.lensPath(path), value, {}) : config,
+      config.local
+    );
     return value;
   }),
   get: (path) => R.view(R.lensPath(path), config)

--- a/src/config/read-config-file.js
+++ b/src/config/read-config-file.js
@@ -1,22 +1,43 @@
 import fs from 'fs';
 import R from 'ramda';
-import configFilePath from './config-file-path';
+import { globalConfigFilePath, localConfigFilePath } from './config-file-path';
 import { ControlledError, errors, handleError } from '../error';
 
 const createEmptyConfigFile = R.curryN(3, fs.writeFileSync)(R.__, R.__, 'utf8');
 const readConfigFile = R.curryN(2, R.compose(JSON.parse, fs.readFileSync))(R.__, 'utf8');
 
-// export default R.compose(JSON.parse, R.tryCatch(readUtf8File, curriedWriteFileSync, {}))(filePath);
+const getGlobalConfig = R.tryCatch(
+  R.compose(readConfigFile, R.always(globalConfigFilePath)),
+  R.ifElse(
+    R.propEq('code', 'ENOENT'),
+    R.converge(
+      R.identity,
+      [
+        R.nthArg(1),
+        R.compose(
+          createEmptyConfigFile(globalConfigFilePath),
+          defaults => JSON.stringify(defaults, null, 2),
+          R.nthArg(1)
+        )
+      ]
+    ),
+    () => handleError(new ControlledError(errors.config.malformedFile))
+  )
+);
 
+const getLocalConfig = R.tryCatch(
+  R.compose(R.set(R.lensProp('local'), true), readConfigFile, R.always(localConfigFilePath)),
+  R.ifElse(
+    R.propEq('code', 'ENOENT'),
+    R.always({}),
+    () => handleError(new ControlledError(errors.config.malformedFile))
+  )
+);
 
-export default (defaults) => {
-  try {
-    return readConfigFile(configFilePath);
-  } catch (e) {
-    if (e.code && e.code === 'ENOENT') {
-      createEmptyConfigFile(configFilePath, JSON.stringify(defaults, null, 2));
-      return defaults;
-    }
-    return handleError(new ControlledError(errors.config.malformedFile));
-  }
-};
+export default R.converge(
+  R.mergeWith(R.ifElse(R.is(Object), R.merge, R.nthArg(1))),
+  [
+    getGlobalConfig,
+    getLocalConfig
+  ]
+);

--- a/src/config/write-config-file.js
+++ b/src/config/write-config-file.js
@@ -1,5 +1,8 @@
 import fs from 'fs';
-import configFilePath from './config-file-path';
+import { globalConfigFilePath, localConfigFilePath } from './config-file-path';
 
-export default (data) =>
-  fs.writeFileSync(configFilePath, JSON.stringify(data, null, 2), { encoding: 'utf8', flag: 'w' });
+export default (data, local = false) =>
+  fs.writeFileSync(
+    local ? localConfigFilePath : globalConfigFilePath,
+    JSON.stringify(data, null, 2), { encoding: 'utf8', flag: 'w' }
+  );


### PR DESCRIPTION
* feat(config): allow to have local config files
  * Files overwrite the global config.
  * Ramdify read config function.
  * Write config function will only update the modified keys if using a
  local file.
  * Define constants for the global and local config files path.
* chore: ignore .fotingo file

Fixes #7.