### PR TITLE
feat(Github): show error message when PR already exists

### DIFF
--- a/src/error/errors.js
+++ b/src/error/errors.js
@@ -12,7 +12,8 @@ export default {
     cantConnect: 'We can\' connect to github right now. Try in a few moments',
     invalidLabel: 'One of the labels you typed does not exist.',
     pullRequestDescriptionInvalid: 'The description provided for the pull request is not valid',
-    tokenInvalid: 'The provided Github token is not valid'
+    tokenInvalid: 'The provided Github token is not valid',
+    pullRequestAlreadyExists: 'A pull request already exists for \'${name}\''
   },
   jira: {
     cantWorkOnIssue: 'It looks like you can\'t work on this issue right now. It may have already been fixed or someone else may be working on it.',

--- a/src/error/index.js
+++ b/src/error/index.js
@@ -1,6 +1,6 @@
 import R from 'ramda';
 import errors from './errors';
-import { debugCurried, error } from '../util';
+import { debug, debugCurried, error } from '../util';
 import reporter from '../reporter';
 
 export class ControlledError extends Error {
@@ -29,11 +29,12 @@ export const handleError = R.ifElse(
   handleUnknownError
 );
 // String -> Promise -> Promise
-export const catchPromiseAndThrow = (module, e) => p => p.catch(err => {
+export const catchPromiseAndThrow = (module, e, parameters) => p => p.catch(err => {
   if (R.is(Function, e)) {
-    throwControlledError(e(err))(err);
+    debug(module, err);
+    throwControlledError(e(err), parameters)(err);
   } else {
-    R.compose(throwControlledError(e), debugCurried(module, err))(err);
+    R.compose(throwControlledError(e, parameters), debugCurried(module, err))(err);
   }
 });
 export { errors };

--- a/src/git/github/index.js
+++ b/src/git/github/index.js
@@ -157,7 +157,17 @@ export default {
         R.composeP(
           R.compose(wrapInPromise, R.set(R.lensProp('pullRequest'), R.__, { branchInfo })),
           addLabelsToPullRequest(config, project, branchInfo),
-          submitPullRequest(config, project, branchInfo)
+          R.compose(
+            catchPromiseAndThrow('github', e => {
+              switch (e.code) {
+                case 500:
+                  return errors.github.cantConnect;
+                default:
+                  return errors.github.pullRequestAlreadyExists;
+              }
+            }, branchInfo),
+            submitPullRequest(config, project, branchInfo)
+          )
         )
       ),
       debugCurriedP('github', 'Submitting pull request to github'),


### PR DESCRIPTION

Error handling can be done better, but the typical error would be duplicated PR.
Fotingo already checks for empty descriptions and authentication is performed
on initialization, so it is unlikely that other error happen. If it does,
then they will be added as they appear.

Fixes #25.