### PR TITLE
feat(start): allow user to define branch name templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,30 @@ fotingo can be used to create pull requests in github without having to connect 
 current branch you can just run `fotingo review -s`. The default base branch for pull requests is *master*, but that can be
 overwritten by modifying the config files or using the `-b` option.
 
+### Issue types
+
+The first time the tool connects with Jira, it will fetch all the possible issue types and save them in the config file under `jira.issueTypes`. It will also associate a short name to any of these types. By default, the short name will be the
+first letter of the name, except for stories that it will be *f* and for tasks, which will be *c*.
+
+### Customizing branch names
+
+The default branch name fotingo creates can be overriden in the config file by setting a template under `jira.templates.branch` and using `{` and `}` to interpolate the deseired data. The data that is currently
+passed to the template is the following:
+
+* `issue.shortName`. The a short name that represents a Jira issue type (e.g. *f* for features).
+* `issue.key`. The key of the issue.
+* `issue.sanitizedSummary`. This is the summary of the issuebut sanitized so a branch name can be created with it.
+
+An example config file with a custom branch name may look like this:
+
+    {
+      "jira": {
+        "templates": {
+          "branch": "{issue.shortName}-{issue.key}"
+        }
+      }
+    }
+
 ## Debugging
 
 If you run into problems, you can get a more verbose output of the tool by adding:

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,5 @@
 import R from 'ramda';
-import readConfigFile from './read-config-file';
+import readConfigFile, { getLocalConfig } from './read-config-file';
 import writeConfigFile from './write-config-file';
 
 let config = readConfigFile({
@@ -37,7 +37,10 @@ const data = {
       inMemoryConfig = set(path, value, inMemoryConfig);
     } else {
       config = set(path, value, config);
-      writeConfigFile(config.local ? R.set(R.lensPath(path), value, {}) : config, config.local);
+      writeConfigFile(
+        config.local ? R.set(R.lensPath(path), value, R.omit(['local'], getLocalConfig())) : config,
+        config.local,
+      );
     }
     return value;
   }),

--- a/src/config/read-config-file.js
+++ b/src/config/read-config-file.js
@@ -22,7 +22,7 @@ const getGlobalConfig = R.tryCatch(
   ),
 );
 
-const getLocalConfig = R.tryCatch(
+export const getLocalConfig = R.tryCatch(
   R.compose(R.set(R.lensProp('local'), true), readConfigFile, R.always(localConfigFilePath)),
   R.ifElse(R.propEq('code', 'ENOENT'), R.always({}), () =>
     handleError(new ControlledError(errors.config.malformedFile)),

--- a/src/fotingo-start.js
+++ b/src/fotingo-start.js
@@ -30,7 +30,7 @@ try {
             .then(issueTracker.canWorkOnIssue(user))
             .then(stepCurried(3, `Setting '${issueId}' in progress`, 'bookmark'))
             .then(issueTracker.setIssueStatus({ status: issueTracker.status.IN_PROGRESS }))
-            .then(R.compose(wrapInPromise, git.createBranchName))
+            .then(R.compose(wrapInPromise, git.createBranchName(config)))
             .then(
               R.ifElse(
                 R.partial(R.propEq('branchIssue', true), [program]),

--- a/src/git/util.js
+++ b/src/git/util.js
@@ -19,9 +19,28 @@ const sanitizeSummary = R.compose(
   R.toLower,
 );
 
-// This should go in the issue?
-export const createBranchName = ({ key, fields: { issuetype: { name: type }, summary } }) =>
-  `${ISSUE_TYPES[type]}/${key.toLowerCase()}_${sanitizeSummary(summary)}`;
+const defaultBranchTemplate = '{issue.shortName}/{issue.key}_{issue.sanitizedSummary}';
+
+const getTemplateData = (config, issue) => ({
+  template: config.get(['jira', 'templates', 'branch']) || defaultBranchTemplate,
+  data: {
+    'issue.shortName': config.get(['jira', 'issueTypes', issue.fields.issuetype.id]).shortName,
+    'issue.key': issue.key.toLowerCase(),
+    'issue.sanitizedSummary': sanitizeSummary(issue.fields.summary),
+  },
+});
+
+// Object -> Object -> String
+export const createBranchName = R.curryN(
+  2,
+  R.compose(
+    R.converge(R.reduce((msg, [k, v]) => R.replace(`{${k}}`, v, msg)), [
+      R.prop('template'),
+      R.compose(R.toPairs, R.prop('data')),
+    ]),
+    getTemplateData,
+  ),
+);
 
 export const getProject = R.compose(R.nth(1), R.match(/\/((\w|-)+)$/));
 


### PR DESCRIPTION

* fix(config): do not use empty object when updating local config file
* If the config file had info in a different path than the data being updated if was removed.
* Now the issue types are fetched from Jira and stored in the config file with a short name.  There are some defaults to match the existing behavior (feature and story => f, task => c). In any other cases, the first letter of the type is used for the short name.
* Users can define the templates in the config file under jira => templates => branch. For now this is the data passed to those templates: issue.shortName, issue.key and issue.sanitizedSummary. In order to access them from the template, { and } must be used to interpolate.

Fixes #43, #38.