### PR TITLE
fix(createBranchName): del < and > from sanitized summary

### DIFF
--- a/src/git/util.js
+++ b/src/git/util.js
@@ -21,7 +21,7 @@ const sanitizeSummary = R.compose(
   R.replace(/__+/, '_'),
   R.replace(/\s|\(|\)/g, '_'),
   R.replace(/\/|\./g, '-'),
-  R.replace(/,|\[|]|"|'|”|“|@|’|`|:|\$|\?|\*/g, ''),
+  R.replace(/,|\[|]|"|'|”|“|@|’|`|:|\$|\?|\*|<|>/g, ''),
   R.toLower,
 );
 


### PR DESCRIPTION

These characters are problematic when referencing the branch name in the terminal