### PR TITLE
feat: create a release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ When working on *jira* backed projects, I see a common pattern I repeat several 
 * Create a *github* pull request with a description very similar to the ticket and a link back to the *jira* issue.
 * Set different labels and request people to review the changes.
 * Set the *jira* issue state to *In Review* and add a comment with the pull request URL.
+* Merge the PR and deploy the code via a CI server.
+* Create a Jira release and update the issue fix version and status.
+* Create a github release that points back to jira and have meaningful release notes.
 
 This seems like a reasonable workflow, but when addressing several issues on a given day, this process becomes very cumbersome. Thus... Fotingo.
 
@@ -38,6 +41,13 @@ Fotingo - A CLI tool that does all the work for me. It is composed of two comman
   * Create a new pull request against master with the messages of the commits and a link to the issue. *Default editor will open so user can edit message.*
   * Add labels and review requests to the pull request if any.
   * Set issue to *In Review* and add comment with a link to the pull request.
+
+* `fotingo release -i <issue-id> -i <another-issue-id> <release-name>
+
+  * Create a Jira version with the indicated name.
+  * Set the issues fix version to the newly created version.
+  * Update the issues status to *Done*.
+  * Create a github release pointing to the Jira release. *Default editor will open so use can edit the release notes*.
 
 ## Installation
 
@@ -71,6 +81,7 @@ An example file might look like this:
           "SELECTED_FOR_DEVELOPMENT": 2,
           "IN_PROGRESS": 3,
           "IN_REVIEW": 4
+          "DONE": 5
         },
         "login": "jira_user",
         "password": "jira_password",
@@ -99,6 +110,7 @@ The command line supports the following commands:
  * `fotingo --help` - to display usage information.
  * `fotingo start <issue-id>` - to start working on an issue. Additional options available via `fotingo start -h`.
  * `fotingo review` - to submit the current issue for review.  Additional options available (e.g. adding labels, not using an issue tracker) by using `fotingo review -h`.
+* `fotingo release <release-id>` - to create a release with the issues mentioned in the current branch. Additional options available (e.g specifying more issues to include in the release) by using `fotingo release -h`.
 
 As of today, SSH  is the only supported authorization type for communicating with Github. Your SSH key should be loaded into the SSH agent (i.e. `ssh-add -k path-to-private-key`). Also, fotingo cannot communicate with remotes via HTTPS.
 

--- a/src/error/errors.js
+++ b/src/error/errors.js
@@ -34,6 +34,9 @@ export default {
     issueIdNotValid: 'The name of this issue is not valid. Make sure your input is correct.',
     issueNotFound: 'We have problems finding that issue in Jira',
     userNotLoggedIn: 'User is not logged in',
+    issuesInMultipleProjects:
+      'There are issues associated with different projects. A release can only contain issues associated with a project',
+    releaseNotesInvalid: 'The release notes provided are not valid',
   },
 };
 /* eslint-enable max-len */

--- a/src/error/errors.js
+++ b/src/error/errors.js
@@ -17,6 +17,7 @@ export default {
       "We couldn't find the issue name on the branch. Maybe you should run `fotingo review -n`.",
     noSshKey:
       "It looks like you haven't added you ssh key. Remember to `ssh-add -k path_to_private_key` so we can communicate with the remote repository.",
+    noIssues: "We couldn't find any issue to assciate with the release",
   },
   github: {
     cantConnect: "We can' connect to github right now. Try in a few moments",

--- a/src/fotingo-release.js
+++ b/src/fotingo-release.js
@@ -1,0 +1,26 @@
+import program from 'commander';
+import R from 'ramda';
+
+import { handleError } from './error';
+import config from './config';
+import init from './init';
+import reporter from './reporter';
+
+// const getReleaseName = R.compose(R.head, R.prop('args'));
+
+try {
+  program
+    .option('-n, --no-branch-issue', 'Do not pick issue from the branch name')
+    .option('-s, --simple', 'Do not use any issue tracker')
+    .option('-i, --issue [issue]', 'Specify more issues to include in the release', R.append, [])
+    .parse(process.argv);
+
+  const { step } = reporter.stepFactory(1);
+  step(1, 'Initializing services', 'rocket');
+  init(config, program)
+    .then(R.partial(reporter.footer, [null]))
+    .catch(handleError);
+} catch (e) {
+  handleError(e);
+  program.help();
+}

--- a/src/fotingo-release.js
+++ b/src/fotingo-release.js
@@ -1,25 +1,56 @@
 import program from 'commander';
 import R from 'ramda';
 
+import { getProject } from './git/util';
 import { handleError } from './error';
 import config from './config';
 import init from './init';
 import reporter from './reporter';
+import { wrapInPromise } from './util';
 
-// const getReleaseName = R.compose(R.head, R.prop('args'));
+const getReleaseId = R.compose(R.head, R.prop('args'));
 
 try {
   program
     .option('-n, --no-branch-issue', 'Do not pick issue from the branch name')
-    .option('-s, --simple', 'Do not use any issue tracker')
     .option('-i, --issue [issue]', 'Specify more issues to include in the release', R.append, [])
     .parse(process.argv);
 
-  const { step } = reporter.stepFactory(1);
+  const releaseId = getReleaseId(program);
+  const shouldGetIssue = R.compose(R.equals(true), R.prop('branchIssue'))(program);
+  const project = getProject(process.cwd());
+
+  const { step, stepCurried, stepCurriedP } = reporter.stepFactory(5);
   step(1, 'Initializing services', 'rocket');
-  init(config, program)
-    .then(R.partial(reporter.footer, [null]))
-    .catch(handleError);
+  R.composeP(
+    reporter.footer,
+    ({ git, github, issueTracker }) =>
+      R.composeP(
+        ({ issues, notes }) =>
+          R.composeP(
+            github.createOrUpdateRelease(config, project, notes, releaseId),
+            stepCurriedP(5, `Creating release ${releaseId} in github`, 'ship'),
+            issueTracker.setIssuesFixVersion(issues),
+            stepCurried(4, 'Setting the fix version to the affected issues', 'pencil2'),
+            issueTracker.createVersion(releaseId),
+          )(issues),
+        stepCurried(3, `Creating release ${releaseId} in ${issueTracker.name}`, 'ship'),
+        R.apply(R.merge),
+        R.converge((...promises) => Promise.all(promises), [
+          R.compose(wrapInPromise, R.set(R.lensProp('issues'), R.__, {})),
+          R.composeP(
+            R.set(R.lensProp('notes'), R.__, {}),
+            issueTracker.createReleaseNotes(releaseId),
+          ),
+        ]),
+        promises => Promise.all(promises),
+        R.map(issueTracker.getIssue),
+        issues =>
+          stepCurried(2, `Getting ${issues.join(', ')} from ${issueTracker.name}`, 'bug', issues),
+        git.getIssuesInBranch(config, program.issue, shouldGetIssue),
+      )(),
+    init,
+  )(config, program).catch(handleError);
 } catch (e) {
   handleError(e);
   program.help();

--- a/src/fotingo.js
+++ b/src/fotingo.js
@@ -7,4 +7,5 @@ program
   .version(app.version)
   .command('start [issue-id]', 'start working in a new issue')
   .command('review', 'submit current issue for review')
+  .command('release [release-name]', 'create a release with your changes')
   .parse(process.argv);

--- a/src/git/github/index.js
+++ b/src/git/github/index.js
@@ -33,6 +33,11 @@ const getLabels = R.composeP(
   promisify(github.issues.getLabels),
 );
 
+const createRelease = R.composeP(
+  R.compose(wrapInPromise, R.prop('data')),
+  promisify(github.repos.createRelease),
+);
+
 const authenticate = R.compose(
   wrapInPromise,
   token => github.authenticate(token),
@@ -216,4 +221,12 @@ export default {
       getLabels,
     )({ owner: config.get(['github', 'owner']), repo: project }),
   ),
+  createOrUpdateRelease: (config, project, notes, releaseId) => () =>
+    createRelease({
+      owner: config.get(['github', 'owner']),
+      repo: project,
+      tag_name: releaseId,
+      name: notes.title,
+      body: notes.body,
+    }).then(R.prop('html_url')),
 };

--- a/src/issue-tracker/http-client.js
+++ b/src/issue-tracker/http-client.js
@@ -15,6 +15,7 @@ const handleServerResponse = (resolve, reject) =>
           R.compose(
             debug('http'),
             R.concat('Request failed with status code '),
+            R.toString,
             R.prop('statusCode'),
             R.nth(1),
           )(args);
@@ -53,6 +54,7 @@ export default function(rootUrl) {
   return {
     post: serverCall('POST'),
     get: serverCall('GET', R.__, {}),
+    put: serverCall('PUT'),
     setAuth: ({ login, password }) => {
       auth = { ...auth, user: login, pass: password };
     },

--- a/src/issue-tracker/jira/status.js
+++ b/src/issue-tracker/jira/status.js
@@ -27,12 +27,16 @@ const statusMatcher = statusToFind =>
 export default R.curryN(2, (config, issue) => {
   const askForStatus = R.composeP(
     config.update(['jira', 'status']),
-    R.compose(wrapInPromise, ([BACKLOG, SELECTED_FOR_DEVELOPMENT, IN_PROGRESS, IN_REVIEW]) => ({
-      BACKLOG,
-      SELECTED_FOR_DEVELOPMENT,
-      IN_PROGRESS,
-      IN_REVIEW,
-    })),
+    R.compose(
+      wrapInPromise,
+      ([BACKLOG, SELECTED_FOR_DEVELOPMENT, IN_PROGRESS, IN_REVIEW, DONE]) => ({
+        BACKLOG,
+        SELECTED_FOR_DEVELOPMENT,
+        IN_PROGRESS,
+        IN_REVIEW,
+        DONE,
+      }),
+    ),
     R.compose(wrapInPromise, JSON.parse),
     R.compose(wrapInPromise, R.concat('['), R.concat(R.__, ']')),
     R.compose(
@@ -43,15 +47,15 @@ export default R.curryN(2, (config, issue) => {
       reporter.info,
       R.concat(
         R.__,
-        "\n     We need you to input the ids of the 'Backlog', 'To do', 'In progress', 'In review'\n    " +
+        "\n     We need you to input the ids of the 'Backlog', 'To do', 'In progress', 'In review' and 'Done'\n    " +
           " (one state can represent multiple values (e.g. 'Backlog' and 'To do' could be the same id).\n     " +
           'It all depends on your workflow.\n',
       ),
       R.concat(
         'In order to update the jira issues correctly, we need to know a little bit more about your workflow.\n     ' +
           'We need to identify the different states an issue can be on. We tried inferring those values, but we\n     ' +
-          "were unable to do so. We are looking for 4 specific states: 'Backlog', 'To do', 'In progress'\n     " +
-          "and 'In review'. These are the names and ids of the states the issue can transition to:\n     ",
+          "were unable to do so. We are looking for 5 specific states: 'Backlog', 'To do', 'In progress',\n     " +
+          "'In review' and 'Done'. These are the names and ids of the states the issue can transition to:\n     ",
       ),
     ),
   );
@@ -73,8 +77,8 @@ export default R.curryN(2, (config, issue) => {
       [status.BACKLOG]:
         statusMatcher(status.BACKLOG)(transitions) ||
         statusMatcher(status.SELECTED_FOR_DEVELOPMENT)(transitions),
-      [status.IN_PROGRESS]:
-        statusMatcher(status.IN_PROGRESS)(transitions) || statusMatcher(status.DONE)(transitions),
+      [status.IN_PROGRESS]: statusMatcher(status.IN_PROGRESS)(transitions),
+      [status.DONE]: statusMatcher(status.DONE)(transitions),
       [status.IN_REVIEW]: statusMatcher(status.IN_REVIEW)(transitions),
       [status.SELECTED_FOR_DEVELOPMENT]: statusMatcher(status.SELECTED_FOR_DEVELOPMENT)(
         transitions,

--- a/src/issue-tracker/jira/status.js
+++ b/src/issue-tracker/jira/status.js
@@ -87,8 +87,11 @@ export default R.curryN(2, (config, issue) => {
     }),
   );
 
+  const anyStatusIsMissing = (configStatus = {}) =>
+    R.compose(R.not, R.all(R.contains(R.__, R.keys(configStatus))), R.values)(status);
+
   return R.ifElse(
-    R.compose(R.either(R.isNil, R.isEmpty), R.invoker(1, 'get')(['jira', 'status'])),
+    R.compose(anyStatusIsMissing, R.invoker(1, 'get')(['jira', 'status'])),
     R.partial(R.compose(inferStatus, R.map(R.prop('to')), R.prop('transitions')), [issue]),
     R.compose(wrapInPromise, R.invoker(1, 'get')(['jira', 'status'])),
   )(config);

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -68,7 +68,7 @@ export default {
   },
   footer(artifact) {
     const totalTime = ((Date.now() - startTime) / 1000).toFixed(2);
-    const msg = `Done in ${totalTime}s ${artifact ? `=> ${artifact}` : '.'}`;
+    const msg = `Done in ${totalTime}s${artifact ? ` => ${artifact}` : '.'}`;
     log(prependEmoji(msg, emojis.get('sparkles')));
   },
 };


### PR DESCRIPTION
This command will allow to create a release for the issues in the current branch (or extra issues using the `-i` option). The release process is as follows:

```bash
fotingo release -i <issue-id> -i <another-issue-id> <release-id>
```

* Extract the issues from the branch name (skip this with `-n` option)  and commit messages.
* Create release notes from the affected issues data.
* Allow user to edit the release notes.
* Create a jira version with name `<release-id>`. The release is set to released status.
* Set the fix version of the affected issues to `<release-id>`.
* Set the status of the affected issues to *done*.
* Create a github release for the `<release-id>` tag with the release notes.

For now, there must a be a tag named `<release-id>`. Future  versions could create this tag if it doesn't exist.

The jira version could be set to released after the issues fix version has been modified. Future versions could explore this.

There may be a **BREAKING CHANGE**, but I'm not sure of this. In previous versions, the infer process associated the *DONE* status to fotingo *IN_PROGRESS* status. This is because there was no need for a *DONE* status. Now that there is, the infer process will no longer make this association. Worst case scenario is that now two fotingo status (*IN_PROGRESS* and *DONE*) point to the same Jira status, but that should not be any problem.