### PR TITLE
feat(start): add option to create an issue

### DIFF
--- a/src/error/errors.js
+++ b/src/error/errors.js
@@ -33,11 +33,19 @@ export default {
       'We have trouble authenticating with Jira. Make sure username and password are correct.',
     issueIdNotValid: 'The name of this issue is not valid. Make sure your input is correct.',
     issueNotFound: 'We have problems finding that issue in Jira',
+    issueTypeNotFound: 'We could not find this issue type, make sure it exists',
+    projectNotFound: 'We have problems finding that project in Jira',
     userNotLoggedIn: 'User is not logged in',
     issuesInMultipleProjects:
       'There are issues associated with different projects. A release can only contain issues associated with a project',
     releaseNotesInvalid: 'The release notes provided are not valid',
     releaseNameRequired: 'It looks like you did not specify a release name',
+    issueDescriptionNotValid:
+      'The description of this issue is not valid. Please make sure your input is correct',
+  },
+  start: {
+    createSyntaxError:
+      'In order to create a new issue you need to specify a project and an issue type',
   },
 };
 /* eslint-enable max-len */

--- a/src/fotingo-start.js
+++ b/src/fotingo-start.js
@@ -1,34 +1,74 @@
 import program from 'commander';
 import R from 'ramda';
 
-import { validate } from './issue-tracker/util';
+import { validateIssueId, validateIssueDescription } from './issue-tracker/util';
 import config from './config';
-import { handleError } from './error';
+import { handleError, throwControlledError, errors } from './error';
 import init from './init';
 import reporter from './reporter';
 import { wrapInPromise } from './util';
 
-const getIssueId = R.compose(validate, R.head, R.prop('args'));
+const getMainArgument = validator => R.compose(validator, R.head, R.prop('args'));
+const validateOptions = R.when(
+  R.both(
+    R.propEq('create', true),
+    R.either(
+      R.compose(
+        R.either(R.compose(R.not, R.is(String)), R.either(R.isEmpty, R.isNil)),
+        R.prop('project'),
+      ),
+      R.compose(
+        R.either(R.compose(R.not, R.is(String)), R.either(R.isEmpty, R.isNil)),
+        R.prop('type'),
+      ),
+    ),
+  ),
+  throwControlledError(errors.start.createSyntaxError),
+);
 
 try {
   program
     .option('-b, --branch [branch]', 'Name of the base branch to use')
     .option('-n, --no-branch-issue', 'Do not create a branch with the issue name')
+    .option('-c, --create', 'Create a new issue instead of searching for it')
+    .option('-p, --project [project]', 'Name of the project where to create the issue')
+    .option('-t, --type [type]', 'Type of the issue to be created')
     .parse(process.argv);
+  validateOptions(program);
   config.update(['git', 'branch'], program.branch, true);
-  const issueId = getIssueId(program);
+  const isCreating = R.propEq('create', true);
+  const issueIdOrDescription = getMainArgument(
+    isCreating ? validateIssueDescription : validateIssueId,
+  )(program);
   const { step, stepCurried } = reporter.stepFactory(program.branchIssue ? 4 : 3);
   step(1, 'Initializing services', 'rocket');
   init(config, program)
     .then(({ git, issueTracker }) =>
       issueTracker
         .getCurrentUser()
-        .then(stepCurried(2, `Getting '${issueId}' from ${issueTracker.name}`, 'bug'))
+        .then(
+          stepCurried(
+            2,
+            isCreating(program)
+              ? `Creating issue in ${issueTracker.name}`
+              : `Getting '${issueIdOrDescription}' from ${issueTracker.name}`,
+            'bug',
+          ),
+        )
         .then(user =>
-          issueTracker
-            .getIssue(issueId)
-            .then(issueTracker.canWorkOnIssue(user))
-            .then(stepCurried(3, `Setting '${issueId}' in progress`, 'bookmark'))
+          R.ifElse(
+            isCreating,
+            R.compose(
+              R.apply(issueTracker.createIssue),
+              R.converge(R.unapply(R.concat(R.__, [issueIdOrDescription])), [
+                R.prop('project'),
+                R.prop('type'),
+              ]),
+            ),
+            () =>
+              issueTracker.getIssue(issueIdOrDescription).then(issueTracker.canWorkOnIssue(user)),
+          )(program)
+            .then(stepCurried(3, `Setting '${issueIdOrDescription}' in progress`, 'bookmark'))
             .then(issueTracker.setIssueStatus({ status: issueTracker.status.IN_PROGRESS }))
             .then(R.compose(wrapInPromise, git.createBranchName(config)))
             .then(

--- a/src/issue-tracker/jira/status.js
+++ b/src/issue-tracker/jira/status.js
@@ -24,7 +24,7 @@ const statusMatcher = statusToFind =>
     R.find(R.compose(R.test(statusRegex[statusToFind]), R.prop('name'))),
   );
 
-export default R.curryN(2, (config, issue) => {
+export default R.curryN(2, (config, issue = { transitions: [] }) => {
   const askForStatus = R.composeP(
     config.update(['jira', 'status']),
     R.compose(

--- a/src/issue-tracker/util.js
+++ b/src/issue-tracker/util.js
@@ -5,6 +5,10 @@ const isPresent = R.complement(R.either(R.isNil, R.isEmpty));
 const issueRegex = new RegExp('^([a-zA-Z]+)\\-(\\d+)$');
 const isValidName = R.test(issueRegex);
 const isInvalid = R.complement(R.both(isPresent, isValidName));
-// string -> boolean
-// eslint-disable-next-line import/prefer-default-export
-export const validate = R.when(isInvalid, throwControlledError(errors.jira.issueIdNotValid));
+// string -> string
+export const validateIssueId = R.when(isInvalid, throwControlledError(errors.jira.issueIdNotValid));
+// string -> string
+export const validateIssueDescription = R.when(
+  R.complement(isPresent),
+  throwControlledError(errors.jira.issueDescriptionNotValid),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4586,7 +4586,7 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
-request@2, request@2.81.0, request@^2.79.0, request@^2.83.0:
+request@2, request@2.81.0, request@^2.79.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -4612,6 +4612,33 @@ request@2, request@2.81.0, request@^2.79.0, request@^2.83.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
+
+request@^2.83.0:
+  version "2.83.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
**Changes**

* fix(yarn): solve issue with request
* feat(start): add option to create an issue

If the -c option is specified, then it will create a new issue. Start  with `-c` needs to know the project `-p`, the type of issue to create  `-t` and a description of the issue.
  
Some extra validation rules needed to be added to the start script.
The jira client now has a method to create an issue.