### PR TITLE
feat: include Jira release URL in release notes

### DIFF
--- a/src/commands/Release.ts
+++ b/src/commands/Release.ts
@@ -7,6 +7,7 @@ import { Emoji, Messenger } from 'src/io/messenger';
 import { CreateRelease } from 'src/issue-tracker/Issue';
 import { Jira } from 'src/issue-tracker/Jira';
 import { Tracker } from 'src/issue-tracker/Tracker';
+import { getReleaseNotes } from 'src/templates/getReleaseNotes';
 
 import { FotingoArguments } from './FotingoArguments';
 import { getLocalChangesInformation, LocalChanges } from './util';
@@ -40,22 +41,34 @@ const getCommandData = (args: FotingoArguments): ReleaseData => {
   };
 };
 
-// TODO Fix return type
-export const cmd = (args: FotingoArguments, messenger: Messenger): Observable<any> => {
+export const cmd = (args: FotingoArguments, messenger: Messenger): Observable<JointRelease> => {
   const git: Git = new Git(args.config.git, messenger);
   const jira: Tracker = new Jira(args.config.jira, messenger);
   const github: Remote = new Github(args.config.github, messenger, git);
   const commandData$ = of(args).pipe(map(getCommandData));
-  return commandData$.pipe(
+
+  const releaseInformation$ = commandData$.pipe(
     switchMap(git.getBranchInfo),
     withLatestFrom(commandData$),
     switchMap(getLocalChangesInformation(jira, messenger)),
     withLatestFrom(commandData$),
     map(buildReleaseData),
+  );
+
+  return releaseInformation$.pipe(
     tap(data => messenger.emit(`Creating release ${data.name}`, Emoji.SHIP)),
     switchMap(jira.createRelease),
     switchMap(jira.setIssuesFixVersion),
-    switchMap(github.createRelease),
+    withLatestFrom(commandData$),
+    switchMap(([release, { useDefaults }]) =>
+      getReleaseNotes(args.config.release, messenger, release, useDefaults).pipe(
+        map(notes => ({
+          notes,
+          release,
+        })),
+      ),
+    ),
+    switchMap(({ notes, release }) => github.createRelease(release, notes)),
     tap((data: JointRelease) =>
       messenger.emit(
         `Release created: ${data.release.url} | ${data.remoteRelease.url}`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,11 +9,13 @@ import * as R from 'ramda';
 
 import { GitConfig, GithubConfig } from './git/Config';
 import { JiraConfig } from './issue-tracker/Config';
+import { ReleaseConfig } from './types';
 
 export interface Config {
   git: GitConfig;
   github: GithubConfig;
   jira: JiraConfig;
+  release: ReleaseConfig;
 }
 
 export const requiredConfigs = [

--- a/src/enhanceConfig.ts
+++ b/src/enhanceConfig.ts
@@ -14,8 +14,8 @@ interface DefaultConfig {
     baseBranch: string;
     pullRequestTemplate: string;
   };
-  jira: {
-    releaseTemplate: string;
+  release: {
+    template: string;
   };
 }
 
@@ -30,8 +30,9 @@ const defaultConfig: DefaultConfig = {
     pullRequestTemplate:
       '{firstIssue.summary}\n\n**Description**\n\n{firstIssue.description}\n\n{fixedIssues}\n\n**Changes**\n\n{changes}\n\n{fotingo.banner}',
   },
-  jira: {
-    releaseTemplate: '{version}\n\n{fixedIssuesByCategory}\n\n{fotingo.banner}',
+  release: {
+    template:
+      '{version}\n\n{fixedIssuesByCategory}\n\nSee [Jira release]({jira.release})\n\n{fotingo.banner}',
   },
 };
 

--- a/src/git/Git.ts
+++ b/src/git/Git.ts
@@ -197,7 +197,7 @@ export class Git {
         if (/no upstream configured for branch/.test(e.message)) {
           return false;
         }
-        this.mapAndThrowError(e);
+        return this.mapAndThrowError(e);
       });
   }
 
@@ -334,7 +334,7 @@ export class Git {
    * known errors
    * @param e Error
    */
-  private mapAndThrowError(e: Error): void {
+  private mapAndThrowError(e: Error): never {
     if (e.message.match(/A branch named .* already exists/)) {
       throw new GitErrorImpl(e.message, GitErrorType.BRANCH_ALREADY_EXISTS);
     }

--- a/src/git/Github.ts
+++ b/src/git/Github.ts
@@ -21,7 +21,7 @@ import { maybeAskUserToSelectMatches } from 'src/io/input-util';
 import { Messenger } from 'src/io/messenger';
 import { parseTemplate } from 'src/io/template-util';
 import { findMatches } from 'src/io/text-util';
-import { Issue, Release } from 'src/issue-tracker/Issue';
+import { Issue, Release, ReleaseNotes } from 'src/issue-tracker/Issue';
 
 import * as GithubApi from '@octokit/rest';
 
@@ -155,10 +155,10 @@ export class Github implements Remote {
   }
 
   @boundMethod
-  public async createRelease(release: Release): Promise<JointRelease> {
+  public async createRelease(release: Release, notes: ReleaseNotes): Promise<JointRelease> {
     const ghRelease = await this.api.repos.createRelease({
-      body: release.notes.body,
-      name: release.notes.title,
+      body: notes.body,
+      name: notes.title,
       owner: this.config.owner,
       repo: this.config.repo,
       tag_name: release.name,

--- a/src/git/Remote.ts
+++ b/src/git/Remote.ts
@@ -1,10 +1,10 @@
-import { Issue, Release } from 'src/issue-tracker/Issue';
+import { Issue, Release, ReleaseNotes } from 'src/issue-tracker/Issue';
 import { BranchInfo } from './Git';
 
 export interface Remote {
   createPullRequest: (data: PullRequestData) => Promise<PullRequest>;
   getLabels: () => Promise<Label[]>;
-  createRelease: (release: Release) => Promise<JointRelease>;
+  createRelease: (release: Release, notes: ReleaseNotes) => Promise<JointRelease>;
   getPossibleReviewers: () => Promise<Reviewer[]>;
 }
 

--- a/src/issue-tracker/Config.ts
+++ b/src/issue-tracker/Config.ts
@@ -3,6 +3,5 @@ export interface JiraConfig {
     login: string;
     token: string;
   };
-  releaseTemplate: string;
   root: string;
 }

--- a/src/issue-tracker/Issue.ts
+++ b/src/issue-tracker/Issue.ts
@@ -121,7 +121,6 @@ export interface ReleaseNotes {
 export interface Release {
   id: string;
   name: string;
-  notes: ReleaseNotes;
   issues: Issue[];
   url?: string;
 }

--- a/src/templates/getReleaseNotes.ts
+++ b/src/templates/getReleaseNotes.ts
@@ -1,0 +1,109 @@
+import {
+  compose,
+  converge,
+  groupBy,
+  head,
+  join,
+  lensProp,
+  map as rMap,
+  mapObjIndexed,
+  prop,
+  split,
+  tail,
+  toPairs,
+  trim,
+  unapply,
+  view,
+  zipObj,
+} from 'ramda';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { editVirtualFile } from 'src/io/file-util';
+import { Messenger } from 'src/io/messenger';
+import { parseTemplate } from 'src/io/template-util';
+import { Issue, IssueType, Release } from 'src/issue-tracker/Issue';
+import { ReleaseConfig, ReleaseNotes } from 'src/types';
+
+enum RELEASE_TEMPLATE_KEYS {
+  VERSION = 'version',
+  FIXED_ISSUES_BY_CATEGORY = 'fixedIssuesByCategory',
+  FOTINGO_BANNER = 'fotingo.banner',
+  JIRA_RELEASE = 'jira.release',
+}
+
+const ISSUE_TYPE_TO_RELEASE_SECTION: { [k in IssueType]: string } = {
+  [IssueType.TASK]: 'Features',
+  [IssueType.SUB_TASK]: 'Features',
+  [IssueType.BUG]: 'Bug fixes',
+  [IssueType.STORY]: 'Features',
+  [IssueType.FEATURE]: 'Features',
+};
+
+/**
+ * Allow the user to edit the initial release notes
+ * @param initialReleaseNotes Initial release notes
+ */
+async function editReleaseNotes(initialNotes: string, messenger: Messenger): Promise<string> {
+  messenger.inThread(true);
+  const notes = await editVirtualFile({
+    extension: 'md',
+    initialContent: initialNotes,
+    prefix: 'fotingo-review',
+  });
+  messenger.inThread(false);
+  return notes;
+}
+
+function getReleaseNotesFromTemplate(data: Release, releaseConfig: ReleaseConfig): string {
+  return parseTemplate<RELEASE_TEMPLATE_KEYS>({
+    data: {
+      [RELEASE_TEMPLATE_KEYS.FIXED_ISSUES_BY_CATEGORY]: compose(
+        join('\n'),
+        rMap(([title, list]) => `# ${title}:\n\n${list}`),
+        toPairs,
+        mapObjIndexed(
+          compose(
+            join('\n'),
+            rMap((issue: Issue) => `* [#${issue.key}](${issue.url}): ${issue.fields.summary}`),
+          ),
+        ),
+        groupBy(compose(lens => view(lens, ISSUE_TYPE_TO_RELEASE_SECTION), lensProp, prop('type'))),
+      )(data.issues),
+      [RELEASE_TEMPLATE_KEYS.VERSION]: data.name,
+      [RELEASE_TEMPLATE_KEYS.FOTINGO_BANNER]:
+        '🚀 Release created with [fotingo](https://github.com/tagoro9/fotingo)',
+      [RELEASE_TEMPLATE_KEYS.JIRA_RELEASE]: data.url || '',
+    },
+    template: releaseConfig.template,
+  });
+}
+
+/**
+ * Generate a function that generates the release notes
+ * for a release
+ * @param releaseConfig Release configuration
+ * @param messenger Messenger
+ */
+export function getReleaseNotes(
+  releaseConfig: ReleaseConfig,
+  messenger: Messenger,
+  release: Release,
+  useDefaults: boolean,
+): Observable<ReleaseNotes> {
+  const initialReleaseNotes = getReleaseNotesFromTemplate(release, releaseConfig);
+  return from(
+    useDefaults ? [initialReleaseNotes] : editReleaseNotes(initialReleaseNotes, messenger),
+  ).pipe(
+    map(
+      converge(unapply(zipObj(['title', 'body'])), [
+        compose<string, string, string, string[], string>(head, split('\n'), trim),
+        compose<string, string, string, string[], string[], string>(
+          join('\n'),
+          tail,
+          split('\n'),
+          trim,
+        ),
+      ]),
+    ),
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,10 +29,15 @@ interface TrackerConfig {
   };
 }
 
+export interface ReleaseConfig {
+  template: string;
+}
+
 export interface Config {
   git: GitConfig;
   github: RemoteConfig;
   jira: TrackerConfig;
+  release: ReleaseConfig;
 }
 
 export interface DefaultConfig {


### PR DESCRIPTION

**Description**

Extract the release note creation from Jira into its own file.
Ask the user for release notes after the Jira release has been created so we can include the URL in them.
Minor bug fixes

**Changes**

* feat: create a method to get the release notes
* chore(types): define type for release config
* chore(config): move release template into new field in config
* chore(Git): fix compiler warning
* chore(Jira): del no longer existing fields
* refactor(Jira): extract release note creation
* chore(Github): update signature to meet new release notes design
* feat(Release): include jira release on the notes

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
