### PR TITLE
Update README.md - release command section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you just want to create a pull request without connecting to Jira at all, you
 
 ### release
 
-`fotingo release -i <issue-id> -i <another-issue-id> <release-name>` - Creates a Github and Jira release
+`fotingo release <release-name> -i <issue-id> -i <another-issue-id>` - Creates a Github and Jira release
 
 - Create a Jira version with the indicated name (e.g. `1.0.5`)
 - Set the issues fix version to the newly created version


### PR DESCRIPTION
A small change of something I ran into while trying to make a release. The order of the  example command given for releasing doesn't work as currently shown.

For example:
Does NOT work: fotingo release -i SCHU-6070 v0.1.30508 
Does work: fotingo release v0.1.30508 -i SCHU-6070

I updated the example command to match the correct order.

Small update for those who are new to the repo.

{firstIssueSummary}

**Description**

{fixedIssues}

**Changes**

{changes}

{fotingo.banner}
