### PR TITLE
fix(Github): several Github minor bug fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
-{firstIssueSummary}
+{summary}
 
 **Description**
+
+{description}
 
 {fixedIssues}
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ You can use `{` and `}` to interpolate the desired data. This is the data that i
   - `branchName`. Name of the branch
   - `changes`. List of the commit messages in the PR
   - `fixedIssues`. Text with the comma separated list of the fixed issues
-  - `firstIssue.summary`. Summary of the first Jira issue in the PR
-  - `firstIssue.description`. Description of the first Jira issue in the PR
+  - `summary`. Pull request summary. Summary of the first Jira issue in the PR or first commit header if there are no fixed issues
+  - `description`. Description of the first Jira issue in the PR or first commit body if there are no fixed issues
   - `fotingo.banner`. Banner that indicates that the release was created with fotingo
 
 - `git.branchTemplate`

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cosmiconfig": "^6.0.0",
     "debug": "^4.1.1",
     "editor": "^1.0.0",
+    "escape-html": "^1.0.3",
     "escape-string-regexp": "^2.0.0",
     "fuse.js": "^3.4.5",
     "git-url-parse": "^11.1.2",
@@ -75,6 +76,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.4",
+    "@types/escape-html": "^0.0.20",
     "@types/escape-string-regexp": "^2.0.1",
     "@types/faker": "^4.1.5",
     "@types/git-url-parse": "^9.0.0",

--- a/src/enhanceConfig.ts
+++ b/src/enhanceConfig.ts
@@ -29,7 +29,7 @@ const defaultConfig: DefaultConfig = {
   github: {
     baseBranch: 'master',
     pullRequestTemplate:
-      '{firstIssue.summary}\n\n**Description**\n\n{firstIssue.description}\n\n{fixedIssues}\n\n**Changes**\n\n{changes}\n\n{fotingo.banner}',
+      '{summary}\n\n**Description**\n\n{description}\n\n{fixedIssues}\n\n**Changes**\n\n{changes}\n\n{fotingo.banner}',
   },
   release: {
     template:

--- a/src/git/Github.ts
+++ b/src/git/Github.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import { boundMethod } from 'autobind-decorator';
+import * as escapeHtml from 'escape-html';
 import {
   compose,
   concat as rConcat,
@@ -7,6 +8,7 @@ import {
   head,
   join,
   map,
+  mapObjIndexed,
   pick,
   prop,
   replace,
@@ -343,7 +345,7 @@ export class Github implements Remote {
   private getPullRequestContentFromTemplate(branchInfo: BranchInfo, issues: Issue[]): string {
     const data = this.getPrSummaryAndDescription(branchInfo, issues);
     return parseTemplate<PR_TEMPLATE_KEYS>({
-      data: {
+      data: mapObjIndexed(escapeHtml, {
         [PR_TEMPLATE_KEYS.CHANGES]: branchInfo.commits
           .reverse()
           .map(c => `* ${c.header}`)
@@ -357,7 +359,7 @@ export class Github implements Remote {
         [PR_TEMPLATE_KEYS.SUMMARY]: data.description,
         [PR_TEMPLATE_KEYS.FOTINGO_BANNER]:
           '🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)',
-      },
+      }),
       template: this.config.pullRequestTemplate,
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,11 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
+"@types/escape-html@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-0.0.20.tgz#cae698714dd61ebee5ab3f2aeb9a34ba1011735a"
+  integrity sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw==
+
 "@types/escape-string-regexp@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/escape-string-regexp/-/escape-string-regexp-2.0.1.tgz#05d249ffde63aba70d1dfdea1e0cad16dcec9629"
@@ -2194,6 +2199,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@*, escape-string-regexp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION

**Description**

This PR fixes some issues related to Github and the creation of PRs. It improves the logic for creating the default summary and description of the PR. It also escapes HTML content from the PR template (I had commit messages referencing some react components and they wouldn't show up in the description as they are not valid HTML). 

BREAKING CHANGE: In the PR template keys `firstIssue.summary` and `firstIssue.description` are now just `summary` and `description`.

**Changes**

* fix(prTemplate): use correct placeholders
* fix(useCmd): exit thread mode when there is an error
* feat(Github): improve PR summary and description
* chore(enhanceConfig): update default template to use new keys
* docs(readme): update docs for PR template keys
* chore(dependencies): add escape-html
* fix(Github): escape HTML in PR data

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
