### PR TITLE
chore(autoAssign): set label for auto update

### DIFF
--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -27,5 +27,5 @@ jobs:
           MERGE_FORKS: 'false'
           MERGE_RETRIES: '6'
           MERGE_RETRY_SLEEP: '10000'
-          UPDATE_LABELS: ''
+          UPDATE_LABELS: 'autoupdate'
           UPDATE_METHOD: 'rebase'


### PR DESCRIPTION

**Description**

Using the empty string prevents multiple dependabot PRs from getting merged

**Changes**

* chore(autoAssign): set label for auto update

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
