### PR TITLE
chore(autoAssign): increase delay to 60s

### DIFF
--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -26,6 +26,6 @@ jobs:
           MERGE_METHOD: 'squash'
           MERGE_FORKS: 'false'
           MERGE_RETRIES: '6'
-          MERGE_RETRY_SLEEP: '10000'
+          MERGE_RETRY_SLEEP: '60000'
           UPDATE_LABELS: 'autoupdate'
           UPDATE_METHOD: 'rebase'

--- a/src/git/Github.ts
+++ b/src/git/Github.ts
@@ -32,10 +32,10 @@ import { JointRelease, Label, PullRequest, PullRequestData, Remote, Reviewer } f
 enum PR_TEMPLATE_KEYS {
   BRANCH_NAME = 'branchName',
   CHANGES = 'changes',
-  DESCRIPTION = 'summary',
+  DESCRIPTION = 'description',
   FIXED_ISSUES = 'fixedIssues',
   FOTINGO_BANNER = 'fotingo.banner',
-  SUMMARY = 'description',
+  SUMMARY = 'summary',
 }
 
 export class Github implements Remote {


### PR DESCRIPTION

**Description**

Increase delay for merge PRs to 60s as it was not enough and fix Github template names, which were mixed.

**Changes**

* chore(autoAssign): increase delay to 60s
* fix(Github): name template keys correctly

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
