### PR TITLE
fix(Jira): ignore ‘ in issue sanitized summary

### DIFF
--- a/src/issue-tracker/jira/Jira.ts
+++ b/src/issue-tracker/jira/Jira.ts
@@ -290,7 +290,7 @@ export class Jira implements Tracker {
         replace(/(_|-)$/, ''),
         replace(/\s|\(|\)|__+/g, '_'),
         replace(/\/|\.|--=/g, '-'),
-        replace(/,|\[|]|"|'|”|“|@|’|`|:|\$|\?|\*|<|>|&|~/g, ''),
+        replace(/,|\[|]|"|'|”|“|@|’|`|:|\$|\?|\*|<|>|&|~|‘/g, ''),
         toLower,
       )(issue.fields.summary),
       summary: issue.fields.summary,


### PR DESCRIPTION

**Description**


This character was not being escaped and was producing some invalid branch names

Fixes #259.

**Changes**

* fix(Jira): ignore ‘ in issue sanitized summary

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
