### PR TITLE
fix(Github): improve caching and add logging

### DIFF
--- a/src/io/cacheable.ts
+++ b/src/io/cacheable.ts
@@ -46,8 +46,9 @@ export function cacheable({
       if (isCacheDisabled) {
         return method.call(this, ...args);
       }
-      const prefix = getPrefix ? getPrefix.call(this) : '';
-      const key = `${prefix}${target.constructor.name}_${String(propertyKey)}`;
+      const prefix = getPrefix ? getPrefix.call(this, ...args) : '';
+      const keyArgs = args.length > 0 ? `_${args.map(val => JSON.stringify(val)).join('_')}` : '';
+      const key = `${prefix}${target.constructor.name}_${String(propertyKey)}${keyArgs}`;
       const cachedValue = await keyv.get(key);
       if (cachedValue) {
         return Promise.resolve(cachedValue);

--- a/src/io/cacheable.ts
+++ b/src/io/cacheable.ts
@@ -26,7 +26,7 @@ export function cacheable({
   minutes,
 }: {
   getPrefix?: () => string;
-  minutes: number;
+  minutes?: number;
 }): Cacheable {
   return (
     target: object,
@@ -48,7 +48,7 @@ export function cacheable({
         return Promise.resolve(cachedValue);
       }
       const result = await method.call(this, ...args);
-      await keyv.set(key, result, minutes * 60 * 1000);
+      await keyv.set(key, result, minutes ? minutes * 60 * 1000 : undefined);
       return Promise.resolve(result);
     };
 

--- a/src/io/cacheable.ts
+++ b/src/io/cacheable.ts
@@ -13,6 +13,8 @@ type Cacheable = (
   descriptor: TypedPropertyDescriptor<PromiseFunction>,
 ) => TypedPropertyDescriptor<PromiseFunction>;
 
+const isCacheDisabled = process.env.FOTINGO_DISABLE_CACHE !== undefined;
+
 /**
  * Decorator that caches the output of the decorated function
  * in an external data source (SQLite DB) so it can be
@@ -41,6 +43,9 @@ export function cacheable({
     }
 
     const cachedFn: PromiseFunction = async function(...args) {
+      if (isCacheDisabled) {
+        return method.call(this, ...args);
+      }
       const prefix = getPrefix ? getPrefix.call(this) : '';
       const key = `${prefix}${target.constructor.name}_${String(propertyKey)}`;
       const cachedValue = await keyv.get(key);

--- a/src/io/debug.ts
+++ b/src/io/debug.ts
@@ -1,0 +1,3 @@
+import createDebugger, { Debugger } from 'debug';
+
+export const debug = createDebugger('fotingo') as Debugger;

--- a/src/io/messenger.ts
+++ b/src/io/messenger.ts
@@ -1,6 +1,6 @@
 import { boundMethod } from 'autobind-decorator';
 import { Observable, Subject } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { mapTo, take } from 'rxjs/operators';
 
 export enum MessageType {
   ERROR = 'error',
@@ -84,6 +84,13 @@ export class Messenger {
 
   public send(data: string): void {
     this.requestSubject.next(data);
+  }
+
+  /**
+   * Pause execution until the user hits enter
+   */
+  public pause(): Observable<void> {
+    return this.request('Press enter to continue', { options: [] }).pipe(mapTo(undefined));
   }
 
   public request<T>(

--- a/src/ui/SelectRequest.tsx
+++ b/src/ui/SelectRequest.tsx
@@ -22,7 +22,7 @@ export function SelectRequest({ onSubmit, request }: SelectRequestProps): JSX.El
       setSelectedIndex((selectedIndex + 1) % items.length);
     }
     if (key.return) {
-      onSubmit(items[selectedIndex].value);
+      onSubmit(items[selectedIndex]?.value);
     }
     if (key.upArrow) {
       setSelectedIndex((((selectedIndex - 1) % items.length) + items.length) % items.length);

--- a/src/ui/SelectRequest.tsx
+++ b/src/ui/SelectRequest.tsx
@@ -18,7 +18,6 @@ export function SelectRequest({ onSubmit, request }: SelectRequestProps): JSX.El
   const [items, setItems] = useState(request.options);
   const [selectedIndex, setSelectedIndex] = useState(0);
   useInput((_, key) => {
-    console.error('There was an input');
     if (key.downArrow) {
       setSelectedIndex((selectedIndex + 1) % items.length);
     }

--- a/test/io/__snapshots__/cacheable.test.ts.snap
+++ b/test/io/__snapshots__/cacheable.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@cacheable caches values returned from the function 1`] = `
+Array [
+  "prefixCacheableClass_cached_\\"test\\"",
+]
+`;
+
+exports[`@cacheable caches values returned from the function 2`] = `
+Array [
+  "prefixCacheableClass_cached_\\"test\\"",
+]
+`;
+
+exports[`@cacheable caches values returned from the function 3`] = `
+Array [
+  "prefixCacheableClass_cached_\\"test\\"",
+  Array [
+    "test",
+    "test",
+  ],
+  3600000,
+]
+`;

--- a/test/io/cacheable.test.ts
+++ b/test/io/cacheable.test.ts
@@ -1,0 +1,65 @@
+import 'jest';
+
+import * as Keyv from 'keyv';
+import { cacheable } from 'src/io/cacheable';
+
+jest.mock('keyv', () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const values: { [k: string]: any } = {};
+  const get = jest.fn((key: string): any => values[key]);
+  const set = jest.fn((key: string, value: any) => {
+    values[key] = value;
+  });
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  return class InMemoryKeyV {
+    static get = get;
+    static set = set;
+    public get = get;
+    public set = set;
+  };
+});
+
+class CacheableClass {
+  private value = 'prefix';
+  private innerMock: () => {};
+
+  constructor(innerMock: () => {}) {
+    this.innerMock = innerMock;
+  }
+
+  @cacheable({
+    getPrefix(this: CacheableClass) {
+      return this.value;
+    },
+    minutes: 60,
+  })
+  cached(name: string): Promise<string[]> {
+    this.innerMock();
+    return Promise.resolve([name, name]);
+  }
+}
+
+describe('@cacheable', () => {
+  test('caches values returned from the function', async () => {
+    const mock = jest.fn();
+    const cacheable = new CacheableClass(mock);
+    await cacheable.cached('test');
+    await cacheable.cached('test');
+    expect(mock).toHaveBeenCalledTimes(1);
+    const getMock = ((Keyv as unknown) as { get: jest.Mock }).get;
+    const setMock = ((Keyv as unknown) as { set: jest.Mock }).set;
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(getMock.mock.calls[0]).toMatchSnapshot();
+    expect(getMock.mock.calls[1]).toMatchSnapshot();
+    expect(setMock).toHaveBeenCalledTimes(1);
+    expect(setMock.mock.calls[0]).toMatchSnapshot();
+  });
+
+  test('propagates any error of the cached function', async () => {
+    const mock = jest.fn(() => {
+      throw new Error('Fail');
+    });
+    const cacheable = new CacheableClass(mock);
+    await expect(cacheable.cached('some name')).rejects.toThrow('Fail');
+  });
+});


### PR DESCRIPTION

**Description**

After having added queues for Github, when the cache expires it takes a long time to get all the data to cache. This PR increases the cache time for most of the GH data and also removes the collabotators as possible reviewers.

It also starts caching Github users globally so they can be resued from repo to repo.

Finally, it also creates a shared debugger and adds some debugging messages for Github as well as a `pause()` method that allows to see output before jumping into things like editing a file in vim.

**Changes**

* feat(cacheable): make TTL optional
* chore(Github): improve caching and remove contributors from reviewers
* chore(cacheable): allow to disable cache via an env var
* chore: create a shared debugger that modules can extend
* fix(SelectRequest): remove unwanted log call
* fix(SelectRequest): make sure the selected index exists
* feat(messenger): add pause method
* chore(Github): add debug info and pause method
* fix(cacheable): use function args as part of the key
* test(cacheable): write tests for the function

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
