### PR TITLE
feat:(start): ask user to select issues if none was specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ A CLI to ease the interaction between _Git_, _GitHub_ and _Jira_ when working on
 Run:
 
 ```bash
-yarn global add fotingo@next
-```
-
-Or if you prefer npm:
-
-```bash
 npm install -g fotingo@next
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The command line supports three main commands: `start`, `review` and `release`.
 
 ### start
 
-`fotingo start <issue-id>` - Start working on a new issue.
+`fotingo start [issue-id]` - Start working on a new issue.
+
+If no `issue-id` is specified, then fotingo will display a list with all the tickets assigned to you.
 
 - Assign the issue to current user
 - Clean current working directory (stash it)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fotingo",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "description": "A CLI to ease the interaction between git, github and jira.",
   "main": "lib/fotingo.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fotingo",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "A CLI to ease the interaction between git, github and jira.",
   "main": "lib/fotingo.js",
   "bin": {

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -4,7 +4,7 @@
 
 import { Argv } from 'yargs';
 
-export const command = 'start <issue-id|issue-title>';
+export const command = 'start [issue-id|issue-title]';
 export const describe = 'Start working in a new issue';
 export function builder(yargs: Argv): Argv {
   return yargs

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -73,7 +73,13 @@ export const run: (args: FotingoArguments) => void = R.ifElse(
         });
       },
       [
-        R.compose((path: string) => require(path).cmd, R.concat('./'), R.head, R.prop('_')),
+        R.compose(
+          (path: string) => require(path).cmd,
+          R.concat('./'),
+          R.replace(/^./, R.toUpper),
+          R.head,
+          R.prop('_'),
+        ),
         (a: FotingoArguments): FotingoArguments => ({
           ...a,
           config: enhanceConfigWithRuntimeArgs(a.config, a),

--- a/src/issue-tracker/Tracker.ts
+++ b/src/issue-tracker/Tracker.ts
@@ -16,6 +16,7 @@ export interface Tracker {
   createIssueForCurrentUser: (data: CreateIssue) => Observable<Issue>;
   createRelease: (data: CreateRelease) => Observable<Release>;
   getCurrentUser: () => Observable<User>;
+  getCurrentUserOpenIssues: () => Observable<Issue[]>;
   getIssue: (issueId: string) => Observable<Issue>;
   isValidIssueName: (name: string) => boolean;
   setIssueStatus: (status: IssueStatus, issueId: string) => Observable<Issue>;

--- a/src/issue-tracker/jira/types.ts
+++ b/src/issue-tracker/jira/types.ts
@@ -26,6 +26,12 @@ export interface JiraIssue {
   url: string;
 }
 
+export interface JiraIssueStatus {
+  description: string;
+  id: string;
+  name: string;
+}
+
 export interface IssueTypeData {
   id: number;
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,12 +76,12 @@ export enum IssueStatus {
 
 // TODO This should be Jira only
 export interface User {
+  accountId: string;
   groups: {
     items: {
       name: string;
     };
   };
-  key: string;
 }
 
 export interface Issue {

--- a/test/issue-tracker/__snapshots__/Jira.test.ts.snap
+++ b/test/issue-tracker/__snapshots__/Jira.test.ts.snap
@@ -8,12 +8,12 @@ Object {
 
 exports[`jira getCurrentUser should get the current user 1`] = `
 Object {
+  "accountId": "Olaf_Kunze19",
   "groups": Object {
     "items": Object {
       "name": "asda",
     },
   },
-  "key": "Olaf_Kunze19",
 }
 `;
 

--- a/test/lib/data.ts
+++ b/test/lib/data.ts
@@ -67,12 +67,12 @@ export const data = {
   },
   createJiraUser(): User {
     return {
+      accountId: faker.internet.userName(),
       groups: {
         items: {
           name: 'asda',
         },
       },
-      key: faker.internet.userName(),
     };
   },
   createHttpResponse<T>(body: T): HttpResponse<T> {


### PR DESCRIPTION

**Description**

This PR introduces the first version (very early stage) of a start cmd where no issue needs to be specified. In that case, the user is prompted with the list of the top 15 issues they are assigned that are in Backlog or selected for development (excluding epics). 


**TODOs**

- [x] Add docs
- [x] Improve the code and address all the TODOs


**Changes**

* chore(Jira): define type for Issue status
* chore(Tracker): add method to interface to get current user issues
* fix(types): use new value that jira returns
* feat(io): allow 0 limit and add allowTextSearch option
* feat(Jira): add methods to get statuses and current user open issues
* feat(start): make issue-id|title optional
* feat(Start): ask user to select an issue if none was specified
* test: update failing tests

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
