### PR TITLE
fix(release-notes): add extra line between issue types

### DIFF
--- a/src/io/file.ts
+++ b/src/io/file.ts
@@ -1,4 +1,4 @@
-import * as editor from 'editor';
+import editor from 'editor';
 import * as fs from 'fs';
 import { resolve } from 'path';
 import { zipObj } from 'ramda';

--- a/src/templates/getReleaseNotes.ts
+++ b/src/templates/getReleaseNotes.ts
@@ -57,7 +57,7 @@ function getReleaseNotesFromTemplate(data: Release, releaseConfig: ReleaseConfig
   return parseTemplate<RELEASE_TEMPLATE_KEYS>({
     data: {
       [RELEASE_TEMPLATE_KEYS.FIXED_ISSUES_BY_CATEGORY]: compose(
-        join('\n'),
+        join('\n\n'),
         rMap(([title, list]) => `# ${title}:\n\n${list}`),
         toPairs,
         mapObjIndexed(

--- a/test/lib/data.ts
+++ b/test/lib/data.ts
@@ -3,7 +3,7 @@ import { GitConfig } from 'src/git/Config';
 import { JiraConfig } from 'src/issue-tracker/jira/Config';
 import { JiraIssue } from 'src/issue-tracker/jira/types';
 import { HttpResponse } from 'src/network/HttpClient';
-import { Issue, IssueType, User } from 'src/types';
+import { Issue, IssueType, Release, ReleaseConfig, User } from 'src/types';
 
 /**
  * Data factory used to generate mock data for the tests
@@ -34,10 +34,10 @@ export const data = {
       url: faker.internet.url(),
     };
   },
-  createIssue(): Issue {
+  createIssue(type?: IssueType): Issue {
     const summary = faker.name.jobDescriptor();
     const sanitizedSummary = faker.helpers.slugify(summary);
-    const issueType = faker.random.arrayElement(Object.values(IssueType));
+    const issueType = type || faker.random.arrayElement(Object.values(IssueType));
     return {
       description: faker.lorem.paragraph(),
       id: faker.random.number(5000),
@@ -65,6 +65,12 @@ export const data = {
       },
     };
   },
+  createReleaseConfig(): ReleaseConfig {
+    return {
+      template:
+        '{version}\n\n{fixedIssuesByCategory}\n\nSee [Jira release]({jira.release})\n\n{fotingo.banner}',
+    };
+  },
   createJiraUser(): User {
     return {
       accountId: faker.internet.userName(),
@@ -73,6 +79,14 @@ export const data = {
           name: 'asda',
         },
       },
+    };
+  },
+  createRelease(): Release {
+    return {
+      id: faker.random.word(),
+      issues: [data.createIssue(IssueType.BUG), data.createIssue(IssueType.FEATURE)],
+      name: faker.random.word(),
+      url: faker.internet.url(),
     };
   },
   createHttpResponse<T>(body: T): HttpResponse<T> {

--- a/test/templates/__snapshots__/getReleaseNotes.test.ts.snap
+++ b/test/templates/__snapshots__/getReleaseNotes.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getReleaseNotes generates the release notes from the template 1`] = `
+Object {
+  "body": "
+# Bug fixes:
+
+* [#FOTINGO-3854](https://julianne.biz): Corporate
+
+# Features:
+
+* [#FOTINGO-107](http://morris.com): Legacy
+
+See [Jira release](http://benjamin.info)
+
+🚀 Release created with [fotingo](https://github.com/tagoro9/fotingo)",
+  "title": "Soft",
+}
+`;

--- a/test/templates/getReleaseNotes.test.ts
+++ b/test/templates/getReleaseNotes.test.ts
@@ -1,0 +1,17 @@
+import 'jest';
+
+import { Messenger } from 'src/io/messenger';
+import { getReleaseNotes } from 'src/templates/getReleaseNotes';
+import { data } from 'test/lib/data';
+
+describe('getReleaseNotes', () => {
+  test('generates the release notes from the template', async () => {
+    const notes = await getReleaseNotes(
+      data.createReleaseConfig(),
+      (jest.fn() as unknown) as Messenger,
+      data.createRelease(),
+      true,
+    ).toPromise();
+    expect(notes).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION

**Description**

This PR fixes the release notes so there is an empty line between the different issue types. Although in rendered md it looks good, it doesn't look good on the text version.

It also fixes an issue with the way `editor` was being imported

Fixes #339

**Changes**

* fix(release-notes): add extra line between issue types
* fix(file): import editor correctly

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
