### PR TITLE
refactor: replace module-alias with tscpaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ jspm_packages
 /lib/
 .vscode/
 pack/
+
+# oclif builds
+fotingo-*.tgz

--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-require('module-alias/register');
 
 require('@oclif/command')
   .run()

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "ink-spinner": "^3.0.1",
     "ink-text-input": "^3.2.0",
     "keyv": "^4.0.0",
-    "module-alias": "^2.2.0",
     "node-emoji": "^1.10.0",
     "ramda": "^0.27.0",
     "react": "^16.8.6",
@@ -148,9 +147,6 @@
   },
   "engines": {
     "node": ">=10.0.0"
-  },
-  "_moduleAliases": {
-    "src": "./lib"
   },
   "resolutions": {
     "lodash": ">= 4.5.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "/oclif.manifest.json"
   ],
   "scripts": {
-    "build": "yarn run clean && tsc -p ./",
+    "build": "yarn clean && tsc -p ./ && yarn build:fix-paths",
+    "build:fix-paths": "tscpaths -p ./tsconfig.json -s ./src -o ./lib",
     "circular-dependencies": "madge --circular src",
     "clean": "rimraf lib",
     "coverage": "jest --coverage --silent",
@@ -143,6 +144,7 @@
     "semantic-release": "^17.0.7",
     "serialize-error": "^7.0.0",
     "ts-jest": "^25.2.0",
+    "tscpaths": "^0.0.9",
     "typescript": "^3.6.4"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,1 @@
-require('module-alias/register');
-
 export { run } from '@oclif/command';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2748,7 +2748,7 @@ commander@2.6.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
   integrity sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=
 
-commander@^2.13.0, commander@^2.16.0, commander@^2.19.0, commander@^2.20.3, commander@^2.8.1, commander@~2.20.3:
+commander@^2.13.0, commander@^2.16.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3, commander@^2.8.1, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -10980,6 +10980,14 @@ tsconfig-paths@^3.9.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tscpaths@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/tscpaths/-/tscpaths-0.0.9.tgz#c77abfde6820920f10c64f83c27753b9505814ab"
+  integrity sha512-tz4qimSJTCjYtHVsoY7pvxLcxhmhgmwzm7fyMEiL3/kPFFVyUuZOwuwcWwjkAsIrSUKJK22A7fNuJUwxzQ+H+w==
+  dependencies:
+    commander "^2.20.0"
+    globby "^9.2.0"
 
 tslib@^1, tslib@^1.9.3:
   version "1.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7581,11 +7581,6 @@ modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
 
-module-alias@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
-  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
-
 module-definition@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/module-definition/-/module-definition-3.2.0.tgz#a1741d5ddf60d76c60d5b1f41ba8744ba08d3ef4"


### PR DESCRIPTION

**Description**

`oclif-dev` does not work well with `module-alias` and typescript paths (see https://github.com/oclif/oclif/issues/288). `tscpaths` is a cleaner solution that doesn't require loading extra modules when running fotingo.

**Changes**

* chore(deps): remove module-alias
* chore(deps): install tscpaths
* chore: ignore packed package

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
