### PR TITLE
fix(jira): escape summary characters correctly

### DIFF
--- a/src/issue-tracker/jira/Jira.ts
+++ b/src/issue-tracker/jira/Jira.ts
@@ -317,7 +317,7 @@ export class Jira implements Tracker {
         replace(/([_-])$/, ''),
         replace(/\s|\(|\)|__+/g, '_'),
         replace(/\/|\.|--=/g, '-'),
-        replace(/["$&'*,:<>?@[]`~‘’“”]/g, ''),
+        replace(/["$&'*,:;<>?@[\]`~‘’“”]/g, ''),
         toLower,
       )(issue.fields.summary),
       summary: issue.fields.summary,

--- a/src/issue-tracker/jira/types.ts
+++ b/src/issue-tracker/jira/types.ts
@@ -21,7 +21,6 @@ export interface JiraIssue {
   renderedFields: {
     description?: string;
   };
-  sanitizedSummary: string;
   transitions: IssueTransition[];
   url: string;
 }

--- a/test/issue-tracker/Jira.test.ts
+++ b/test/issue-tracker/Jira.test.ts
@@ -80,4 +80,19 @@ describe('jira', () => {
       }
     });
   });
+
+  describe('getIssue', () => {
+    test('gets and transforms the issue from Jira', async () => {
+      const jiraIssue = data.createJiraIssue({
+        summary: `Issue with a lot of characters "$&'*,:;<>?@[]\`~‘’“”`,
+      });
+      httpClientMocks.get.mockReturnValue(of(data.createHttpResponse(jiraIssue)));
+      const issue = await jira.getIssue(jiraIssue.key).toPromise();
+      expect(issue.sanitizedSummary).not.toContain(':');
+      expect(issue).toMatchSnapshot();
+      expect(httpClientMocks.get).toHaveBeenCalledWith(`/issue/${jiraIssue.key}`, {
+        qs: { expand: 'transitions, renderedFields' },
+      });
+    });
+  });
 });

--- a/test/issue-tracker/__snapshots__/Jira.test.ts.snap
+++ b/test/issue-tracker/__snapshots__/Jira.test.ts.snap
@@ -30,3 +30,16 @@ Object {
   "message": "There was an error",
 }
 `;
+
+exports[`jira getIssue gets and transforms the issue from Jira 1`] = `
+Object {
+  "description": undefined,
+  "id": 2928,
+  "key": "FOTINGO-4266",
+  "project": "soluta",
+  "sanitizedSummary": "issue_with_a_lot_of_characters",
+  "summary": "Issue with a lot of characters \\"$&'*,:;<>?@[]\`~‘’“”",
+  "type": "Story",
+  "url": "https://vallie.biz/browse/FOTINGO-4266",
+}
+`;

--- a/test/lib/data.ts
+++ b/test/lib/data.ts
@@ -9,9 +9,8 @@ import { Issue, IssueType, Release, ReleaseConfig, User } from 'src/types';
  * Data factory used to generate mock data for the tests
  */
 export const data = {
-  createJiraIssue(): JiraIssue {
-    const summary = faker.name.jobDescriptor();
-    const sanitizedSummary = faker.helpers.slugify(summary);
+  createJiraIssue(overrides: { summary?: string } = {}): JiraIssue {
+    const defaultSummary = faker.name.jobDescriptor();
     const issueType = faker.random.arrayElement(Object.values(IssueType));
     return {
       fields: {
@@ -22,14 +21,13 @@ export const data = {
         project: {
           id: faker.lorem.word(),
         },
-        summary,
+        summary: overrides.summary || defaultSummary,
       },
       id: faker.random.number(5000),
       key: `FOTINGO-${faker.random.number(5000)}`,
       renderedFields: {
         description: undefined,
       },
-      sanitizedSummary,
       transitions: [],
       url: faker.internet.url(),
     };


### PR DESCRIPTION

**Description**

There was a typo in the regex that prevented characters from being escaped as intended.

Fixes #549

**Changes**

* chore: allow to pass overrides to mocked issue
* test(jira): add failing test for bug
* chore(jira): remove invalid field in JiraIssue
* fix(jira): escape summary characters correctly

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
