### PR TITLE
chore(messenger): return messages subscription

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -148,6 +148,7 @@ export class Start extends FotingoCommand<Issue | void, StartData> {
   @boundMethod
   private maybeAskUserToSelectIssue(data: StartData): Observable<StartData> {
     if (data.issue === undefined) {
+      this.messenger.emit(`Getting open tickets from ${this.tracker.name}`, Emoji.BUG);
       return this.tracker.getCurrentUserOpenIssues().pipe(
         switchMap((issues: Issue[]) =>
           maybeAskUserToSelectMatches<Issue>(

--- a/src/io/messenger.ts
+++ b/src/io/messenger.ts
@@ -1,5 +1,5 @@
 import { boundMethod } from 'autobind-decorator';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { mapTo, take } from 'rxjs/operators';
 
 export enum MessageType {
@@ -120,8 +120,8 @@ export class Messenger {
     this.subject.error(error);
   }
 
-  public onMessage(fn: (msg: Message) => void): void {
-    this.subject.subscribe({
+  public onMessage(fn: (msg: Message) => void): Subscription {
+    return this.subject.subscribe({
       next: fn,
     });
   }

--- a/src/ui/Fotingo.tsx
+++ b/src/ui/Fotingo.tsx
@@ -6,7 +6,12 @@ import { Messages } from './Messages';
 import { FotingoProps } from './props';
 import { useCmd } from './useCmd';
 
-export function Fotingo({ cmd, isDebugging, messenger }: FotingoProps): JSX.Element {
+export function Fotingo({
+  cmd,
+  isDebugging,
+  messenger,
+  showFooter = true,
+}: FotingoProps): JSX.Element {
   const { executionTime, isDone, isInThread, messages, request, sendRequestData } = useCmd(
     messenger,
     cmd,
@@ -22,7 +27,7 @@ export function Fotingo({ cmd, isDebugging, messenger }: FotingoProps): JSX.Elem
         messages={messages}
       />
       {request && <InputRequest request={request} onSubmit={sendRequestData} />}
-      {!request && executionTime && <Footer executionTime={executionTime} />}
+      {!request && executionTime && showFooter && <Footer executionTime={executionTime} />}
     </>
   );
 }

--- a/src/ui/props.ts
+++ b/src/ui/props.ts
@@ -29,4 +29,5 @@ export interface FotingoProps {
   cmd: () => Observable<unknown>;
   isDebugging: boolean;
   messenger: Messenger;
+  showFooter?: boolean;
 }

--- a/src/ui/ui.tsx
+++ b/src/ui/ui.tsx
@@ -1,10 +1,10 @@
 import React = require('react');
 
-import { render } from 'ink';
+import { Instance, render } from 'ink';
 
 import { Fotingo } from './Fotingo';
 import { FotingoProps } from './props';
 
-export function renderUi(props: FotingoProps): void {
-  render(<Fotingo {...props} />);
+export function renderUi(props: FotingoProps): Instance {
+  return render(<Fotingo {...props} />);
 }

--- a/src/ui/useCmd.ts
+++ b/src/ui/useCmd.ts
@@ -40,7 +40,7 @@ function useMessenger(
   const messengerReference = useRef(messenger);
   const addMessageReference = useRef(addMessage);
   useEffect(() => {
-    messengerReference.current.onMessage((message) => {
+    const subscription = messengerReference.current.onMessage((message) => {
       if (isRequest(message)) {
         setRequest(message);
       } else if (isStatus(message)) {
@@ -49,6 +49,9 @@ function useMessenger(
         addMessageReference.current(message);
       }
     });
+    return () => {
+      subscription.unsubscribe();
+    };
   }, [addMessageReference, messenger, setRequest, setInThread]);
 }
 


### PR DESCRIPTION

**Description**

When migrating to oclif I forgot to migrate the part that asks for required configs to users. When a new user does `fotingo start` the app was crashing because the required config was not there.

This PR adds that feature along with other small things.

**Changes**

* chore(messenger): return messages subscription
* fix(ui): avoid memory leak
* chore(ui): return ink instance
* chore(ui): allow to not render the footer
* feat: ask for required missing configs on startup
* feat(start): add message indicating that we are fetching open tickets

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
