### PR TITLE
feat(config): add tracker -> status

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Fotingo will try to guess most of the information based on the user environment,
 You can create project-specific configuration files. Just create a `.fotingorc` file inside your project root folder.
 This file, needs to be in JSON format as well. You can also overwrite global configuration in this file. An example config file may just be:
 
-```js
+```json
 {
   "github": {
     "baseBranch": "develop"
@@ -101,20 +101,21 @@ This file, needs to be in JSON format as well. You can also overwrite global con
 
 Fotingo will use as many defaults as possible to make it easier to use, but maybe you want to change some of the defaults. In that case, you can update any of the next properties in a fotingo configuration file
 
-| Path                       | Description                                       | default                     |
-| -------------------------- | ------------------------------------------------- | --------------------------- |
-| git.remote                 | Git remote to use                                 | origin                      |
-| git.baseBranch             | Git base branch to use when creating new branches | master                      |
-| git.branchTemplate         | Template used when creating a new branch          | See [templates](#templates) |
-| github.authToken           | Auth token to connect to Github                   | -                           |
-| github.baseBranch          | Base branch to use to create PRs                  | master                      |
-| github.owner               | Owner of the repository when creating a PR        | Extracted from remote       |
-| github.repo                | Name of the repository when creating a PR         | Extracted from remote       |
-| github.pullRequestTemplate | Template to use when creating a PR                | See [templates](#templates) |
-| jira.user.login            | User login to connect to Jira                     | -                           |
-| jira.user.token            | User token to connect to Jira                     | -                           |
-| jira.releaseTemplate       | Template to use when creating a release           | See [templates](#templates) |
-| jira.root                  | URL root to the Jira server                       | -                           |
+| Path                       | Description                                       | default                          |
+| -------------------------- | ------------------------------------------------- | -------------------------------- |
+| git.baseBranch             | Git base branch to use when creating new branches | master                           |
+| git.branchTemplate         | Template used when creating a new branch          | See [templates](#templates)      |
+| git.remote                 | Git remote to use                                 | origin                           |
+| github.authToken           | Auth token to connect to Github                   | -                                |
+| github.baseBranch          | Base branch to use to create PRs                  | master                           |
+| github.owner               | Owner of the repository when creating a PR        | Extracted from remote            |
+| github.pullRequestTemplate | Template to use when creating a PR                | See [templates](#templates)      |
+| github.repo                | Name of the repository when creating a PR         | Extracted from remote            |
+| jira.releaseTemplate       | Template to use when creating a release           | See [templates](#templates)      |
+| jira.root                  | URL root to the Jira server                       | -                                |
+| jira.status                | Regexes to identify workflow statuses             | See [jira status](#jira-status) |
+| jira.user.login            | User login to connect to Jira                     | -                                |
+| jira.user.token            | User token to connect to Jira                     | -                                |
 
 ### Templates
 
@@ -142,6 +143,29 @@ You can use `{` and `}` to interpolate the desired data. This is the data that i
   - `issue.shortName`. A short name that represents a Jira issue type (e.g. _f_ for features).
   - `issue.key`. The key of the issue.
   - `issue.sanitizedSummary`. This is the summary of the issue, sanitized for use as a branch name.
+
+### Jira status
+
+Fotingo internally uses 5 status for an issue: `Backlog`, `Selected for Development`, `In progress`, `In review`, `Done`.
+It automatically tries to map these statuses to Jira statuses, but sometimes projects may have simplified statuses in
+Jira and fotingo won't be able to do the mapping automatically. If that is the case, the `jira.status` config can be
+used to help fotingo do the mapping. Each entry should be a regex to map to that status:
+
+```json
+{
+  "jira": {
+    "status": {
+      "BACKLOG": "backlog",
+      "IN_PROGRESS": "in progress",
+      "IN_REVIEW": "review",
+      "DONE": "done",
+      "SELECTED_FOR_DEVELOPMENT": "(todo)|(to do)|(selected for development)"
+    }
+  }
+}
+```
+
+Multiple fotingo status can point to the same Jira status.
 
 ## Why fotingo?
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "yarn build",
     "test": "FORCE_COLOR=0 jest",
     "version": "oclif-dev readme && git add README.md",
-    "watch": "tsc -w -p ./"
+    "watch": "tsc-watch -p ./ --onSuccess 'yarn build:fix-paths'"
   },
   "husky": {
     "hooks": {
@@ -82,7 +82,7 @@
     "ink-text-input": "^3.2.0",
     "keyv": "^4.0.0",
     "node-emoji": "^1.10.0",
-    "ramda": "^0.27.0",
+    "ramda": "^0.27.1",
     "react": "^16.8.6",
     "read": "^1.0.7",
     "readline": "^1.3.0",
@@ -144,6 +144,7 @@
     "semantic-release": "^17.0.7",
     "serialize-error": "^7.0.0",
     "ts-jest": "^25.2.0",
+    "tsc-watch": "^4.2.9",
     "tscpaths": "^0.0.9",
     "typescript": "^3.6.4"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,16 +7,7 @@ import { writeFileSync } from 'fs';
 import * as path from 'path';
 import * as R from 'ramda';
 
-import { GitConfig, GithubConfig } from './git/Config';
-import { JiraConfig } from './issue-tracker/jira/Config';
-import { ReleaseConfig } from './types';
-
-export interface Config {
-  git: GitConfig;
-  github: GithubConfig;
-  jira: JiraConfig;
-  release: ReleaseConfig;
-}
+import { Config } from './types';
 
 export const requiredConfigs = [
   { path: ['jira', 'user', 'login'], request: "What's your Jira user?" },

--- a/src/issue-tracker/jira/Config.ts
+++ b/src/issue-tracker/jira/Config.ts
@@ -1,7 +1,0 @@
-export interface JiraConfig {
-  root: string;
-  user: {
-    login: string;
-    token: string;
-  };
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,9 @@ interface RemoteConfig {
   repo: string;
 }
 
-interface TrackerConfig {
+export interface TrackerConfig {
   root: string;
+  status: Record<IssueStatus, RegExp>;
   user: {
     login: string;
     token: string;

--- a/test/issue-tracker/Jira.test.ts
+++ b/test/issue-tracker/Jira.test.ts
@@ -21,7 +21,7 @@ let jira: Jira;
 describe('jira', () => {
   beforeEach(() => {
     httpClientMock.mockImplementation(() => httpClientMocks);
-    jira = new Jira(data.createJiraConfig(), new Messenger());
+    jira = new Jira(data.createTrackerConfig(), new Messenger());
   });
 
   afterEach(() => {

--- a/test/lib/data.ts
+++ b/test/lib/data.ts
@@ -1,9 +1,16 @@
 import * as faker from 'faker';
 import { GitConfig } from 'src/git/Config';
-import { JiraConfig } from 'src/issue-tracker/jira/Config';
 import { JiraIssue } from 'src/issue-tracker/jira/types';
 import { HttpResponse } from 'src/network/HttpClient';
-import { Issue, IssueType, Release, ReleaseConfig, User } from 'src/types';
+import {
+  Issue,
+  IssueStatus,
+  IssueType,
+  Release,
+  ReleaseConfig,
+  TrackerConfig,
+  User,
+} from 'src/types';
 
 /**
  * Data factory used to generate mock data for the tests
@@ -54,9 +61,16 @@ export const data = {
       remote: 'origin',
     };
   },
-  createJiraConfig(): JiraConfig {
+  createTrackerConfig(): TrackerConfig {
     return {
       root: faker.internet.url(),
+      status: {
+        [IssueStatus.BACKLOG]: /backlog/i,
+        [IssueStatus.DONE]: /done/i,
+        [IssueStatus.IN_PROGRESS]: /progress/i,
+        [IssueStatus.SELECTED_FOR_DEVELOPMENT]: /to do/i,
+        [IssueStatus.IN_REVIEW]: /review/i,
+      },
       user: {
         login: faker.internet.email(),
         token: faker.internet.password(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,6 +2998,15 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -3462,6 +3471,11 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
+
+duplexer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -4001,6 +4015,19 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+event-stream@=3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -4485,6 +4512,11 @@ from2@^2.1.0, from2@^2.3.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -7208,6 +7240,11 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
   integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -7697,6 +7734,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-cleanup@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
+  integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
+
 node-emoji@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz#8886abd25d9c7bb61802a658523d1f8d2a89b2da"
@@ -7973,7 +8015,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -7988,7 +8029,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -8007,14 +8047,8 @@ npm@^6.10.3:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -8687,6 +8721,13 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
+  dependencies:
+    through "~2.3"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -8939,6 +8980,13 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
+ps-tree@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
+  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
+  dependencies:
+    event-stream "=3.3.4"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -9037,10 +9085,10 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
-ramda@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
-  integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
@@ -10126,6 +10174,13 @@ split2@~1.0.0:
   dependencies:
     through2 "~2.0.0"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
+
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -10208,6 +10263,13 @@ stream-combiner2@~1.1.1:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
 
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  dependencies:
+    duplexer "~0.1.1"
+
 stream-each@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
@@ -10238,6 +10300,11 @@ string-argv@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
+string-argv@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.2.tgz#c5b7bc03fb2b11983ba3a72333dd0559e77e4738"
+  integrity sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==
 
 string-length@^3.1.0:
   version "3.1.0"
@@ -10687,7 +10754,7 @@ through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -10862,6 +10929,17 @@ ts-toolbelt@^6.3.3:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.9.4.tgz#cc3a070d99c557c552b4f69e36f13d430c47a760"
   integrity sha512-muRZZqfOTOVvLk5cdnp7YWm6xX+kD/WL2cS/L4zximBRcbQSuMoTbQQ2ZZBVMs1gB0EZw1qThP+HrIQB35OmEw==
+
+tsc-watch@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/tsc-watch/-/tsc-watch-4.2.9.tgz#d93fc74233ca4ef7ee6b12d08c0fe6aca3e19044"
+  integrity sha512-DlTaoDs74+KUpyWr7dCGhuscAUKCz6CiFduBN7R9RbLJSSN1moWdwoCLASE7+zLgGvV5AwXfYDiEMAsPGaO+Vw==
+  dependencies:
+    cross-spawn "^7.0.3"
+    node-cleanup "^2.1.2"
+    ps-tree "^1.2.0"
+    string-argv "^0.1.1"
+    strip-ansi "^6.0.0"
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION

**Description**

This config allows to override the default mapping that fotingo uses to map internal issue statuses to the Jira ones.

**Changes**

* chore(config): import correct definition
* chore(scripts): use tsc-watch
* feat(config): add tracker -> status
* chore(jira): remove unused interface
* refactor(jira): use status regexes from config
* chore(config): enhance config with default status regexes
* docs(readme): add docs for new status config

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
