### PR TITLE
fix(github): don't fail when using defaults and a match is not found

### DIFF
--- a/src/io/input.ts
+++ b/src/io/input.ts
@@ -41,7 +41,7 @@ export function maybeAskUserToSelectMatches<T>(
 ): Promise<T[]> {
   return series(
     data.map((matches, i) => (): Promise<T> => {
-      if (!matches || matches.length === 0) {
+      if (!useDefaults && (!matches || matches.length === 0)) {
         throw new Error(`No match found for ${options[i]}`);
       }
       if (useDefaults || matches.length === 1) {


### PR DESCRIPTION

**Description**

Do not fail when using defaults and a reviewer / label is not found. Typically defaults are used from CI and we don't want the whole thing to fail.

**Changes**

* fix(github): don't fail when using defaults and a match is not found

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
