### PR TITLE
fix(ui): catch errors that happen before UI starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,10 +97,10 @@
   "devDependencies": {
     "@commitlint/cli": "^9.0.1",
     "@commitlint/config-conventional": "^9.1.1",
+    "@jest/globals": "^26.0.1",
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
     "@octokit/types": "^5.0.0",
-    "@jest/globals": "^26.0.1",
     "@semantic-release/git": "^9.0.0",
     "@types/debug": "^4.1.4",
     "@types/escape-html": "^1.0.0",

--- a/src/cli/FotingoCommand.ts
+++ b/src/cli/FotingoCommand.ts
@@ -115,7 +115,10 @@ export abstract class FotingoCommand<T, R> extends Command {
 
   async run(): Promise<void> {
     const { waitUntilExit } = renderUi({
-      cmd: () => this.runCmd(of(this.getCommandData())),
+      cmd: () => {
+        const commandData = this.getCommandData();
+        return this.runCmd(commandData instanceof Observable ? commandData : of(commandData));
+      },
       isDebugging: process.env.DEBUG !== undefined,
       messenger: this.messenger,
     });
@@ -169,7 +172,7 @@ export abstract class FotingoCommand<T, R> extends Command {
     ).pipe(map(zipObj(['branchInfo', 'issues']))) as unknown) as ObservableInput<LocalChanges>;
   }
 
-  protected abstract getCommandData(): R;
+  protected abstract getCommandData(): Observable<R> | R;
 
   protected abstract runCmd(commandData$: Observable<R>): Observable<T>;
 }

--- a/src/util/text.ts
+++ b/src/util/text.ts
@@ -12,7 +12,7 @@ interface SearchOptions<T extends Searchable> {
   // before searching for the exact match
   cleanData?: (item: string) => string;
   data: T[];
-  fields: (keyof T)[];
+  fields?: (keyof T)[];
 }
 /**
  * Given a search function and the data where to search, return a list of items matching any of the strings to match
@@ -33,7 +33,7 @@ const getSearcher = <T extends Searchable>(
   options: SearchOptions<T>,
 ): { search: (s: string) => Fuse.FuseResult<T>[] } => {
   const fuse = new Fuse<T>(options.data, {
-    keys: options.fields as string[],
+    keys: (options.fields || []) as string[],
     includeMatches: false,
     includeScore: false,
     isCaseSensitive: false,
@@ -44,7 +44,7 @@ const getSearcher = <T extends Searchable>(
     return {
       search(s: string): Fuse.FuseResult<T>[] {
         const exactMatch = options.data.find((item) =>
-          options.fields.some((field) => {
+          (options.fields || []).some((field) => {
             const cleanedData = options.cleanData
               ? options.cleanData(String(item[field]))
               : item[field];


### PR DESCRIPTION

**Description**

This PR updates the start command so that the issue type option is fuzzy searched so less letters can be used. It also removes the `sub-task` type, as those can't be created via fotingo.

**Changes**

* fix(ui): catch errors that happen before UI starts
* chore: order dev dependencies
* chore(text-utils): make fields optional to allow for str searches
* chore(command): allow command data to be an observable
* feat(start): use fuzzy search to detect issue type

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
