### PR TITLE
feat(release): add option to not create Github release

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -224,7 +224,7 @@ export interface RemoteRelease {
 
 export interface JointRelease {
   release: Release;
-  remoteRelease: RemoteRelease;
+  remoteRelease?: RemoteRelease;
 }
 
 export interface Remote {
@@ -269,6 +269,9 @@ export interface ReleaseData {
     enabled: boolean;
   };
   useDefaults: boolean;
+  vcs: {
+    enabled: boolean;
+  };
 }
 
 export interface LocalChanges {


### PR DESCRIPTION

**Description**

Add option `-n` to not create a Github release. This can be useful especially when using `semantic-release-fotingo`.

**Changes**

* feat(release): add option to not create Github release

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
