### PR TITLE
fix(github): use contributors api instead of collaborators

### DIFF
--- a/src/git/Github.ts
+++ b/src/git/Github.ts
@@ -369,7 +369,7 @@ export class Github implements Remote {
   private async listContributors(): Promise<Array<{ login: string }>> {
     const collaborators = await this.queueCall(
       () =>
-        this.api.repos.listCollaborators({
+        this.api.repos.listContributors({
           owner: this.config.owner,
           per_page: 100,
           repo: this.config.repo,


### PR DESCRIPTION
The collaborators API doesn't seem to be working. I really don't know if it is a token issue or what really 

**WORKING**
```
curl \
-H "authorization: token [YOUR_TOKEN_HERE]" \
https://api.github.com/repos/turo/dunlop/contributors\?per_page=1
```

**NOT WORKING**
```
curl \
-H "authorization: token [YOUR_TOKEN_HERE]" \
https://api.github.com/repos/turo/dunlop/collaborators\?per_page=1
```
