### PR TITLE
chore: correct the example for local config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ config file may just be:
 
 ```json
 {
-  "github": {
+  "git": {
     "baseBranch": "develop"
   }
 }


### PR DESCRIPTION


Readme change

**Description**

Configuration example does not work, fix by changing `github` to `git`.


