### PR TITLE
Allow viewing "selected for development" tickets

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface Issue {
     id: string;
     key: string;
   };
+  raw?: unknown;
   sanitizedSummary: string;
   summary: string;
   type: IssueType;

--- a/test/git/__snapshots__/Branch.test.ts.snap
+++ b/test/git/__snapshots__/Branch.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Branch getName ignores unknown template data 1`] = `"{does_not_exist}"`;
 
-exports[`Branch getName replaces the placeholders with the issue data 1`] = `"fotingo-2484.c.Legacy"`;
+exports[`Branch getName replaces the placeholders with the issue data 1`] = `"fotingo-2484.d.Legacy"`;

--- a/test/issue-tracker/Jira.test.ts
+++ b/test/issue-tracker/Jira.test.ts
@@ -98,4 +98,23 @@ describe('jira', () => {
       });
     });
   });
+
+  describe('getCurrentUserOpenIssues', () => {
+    it('gets the issues in all the configured selected for development status regexes', async () => {
+      httpClientMocks.get.mockReturnValueOnce(of(data.createHttpResponse(data.createJiraUser())));
+      httpClientMocks.get.mockReturnValueOnce(
+        of(data.createHttpResponse(data.createJiraStatuses())),
+      );
+      httpClientMocks.get.mockReturnValueOnce(of(data.createHttpResponse({ issues: [] })));
+      await lastValueFrom(jira.getCurrentUserOpenIssues());
+      expect(httpClientMocks.get.mock.calls[2][1]).toMatchInlineSnapshot(`
+        {
+          "qs": {
+            "expand": "transitions, renderedFields",
+            "jql": "assignee=Jerry.Rosenbaum AND status IN ('backlog','To do','to do') ORDER BY CREATED DESC",
+          },
+        }
+      `);
+    });
+  });
 });

--- a/test/issue-tracker/__snapshots__/Jira.test.ts.snap
+++ b/test/issue-tracker/__snapshots__/Jira.test.ts.snap
@@ -43,7 +43,7 @@ exports[`jira getIssue gets and transforms the issue from Jira 1`] = `
   },
   "sanitizedSummary": "issue_with_a_lot_of_characters",
   "summary": "Issue with a lot of characters "$&'*,:;<>?@[]\`~‘’“”",
-  "type": "Sub-task",
+  "type": "Task",
   "url": "https://wee-codling.biz/browse/FOTINGO-1314",
 }
 `;

--- a/test/lib/data.ts
+++ b/test/lib/data.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { GitConfig } from 'src/git/Config';
-import { JiraIssue } from 'src/issue-tracker/jira/types';
+import { JiraIssue, JiraIssueStatus } from 'src/issue-tracker/jira/types';
 import { HttpResponse } from 'src/network/HttpClient';
 import {
   Config,
@@ -106,6 +106,15 @@ export const data = {
         },
       },
     };
+  },
+  createJiraStatuses(): JiraIssueStatus[] {
+    return ['To do', 'to do', 'selected for development', 'backlog', 'in progress'].map(
+      (statusName) => ({
+        description: faker.lorem.paragraph(),
+        id: String(faker.datatype.number(5000)),
+        name: statusName,
+      }),
+    );
   },
   createRelease(): Release {
     return {


### PR DESCRIPTION
This commit fixes enables browsing and starting of tickets with the status "selected for development"

**Description**

The enhanceConfig had a setting where SELECTED_FOR_DEVELOPMENT status regex matches against `todo`, `to do`, and `selected for development`. When executing `fotingo start`, the filter is built up based on tickets which match the statuses provided by that JIRA instance. However, the SELECTED_FOR_DEVELOPMENT config, since it matches statuses with the name of `todo` or `to do` as well as `selected for development`, would query using the wrong status, trying to match `todo` instead of `selected for development`, meaning all the tickets with status `selected for development` would not match the filter.

**Changes**

Update enhanceConfig.ts

{fotingo.banner}
