### PR TITLE
fix(jira): use rest v3 api for JQL search

### DIFF
--- a/test/issue-tracker/Jira.test.ts
+++ b/test/issue-tracker/Jira.test.ts
@@ -120,6 +120,7 @@ describe('jira', () => {
         {
           "qs": {
             "expand": "transitions, renderedFields",
+            "fields": "*all",
             "jql": "assignee=Jerry.Rosenbaum AND status IN ('backlog','To do','to do') ORDER BY CREATED DESC",
           },
         }


### PR DESCRIPTION

**Description**

The `fotingo start` cmd stopped working because the v2 api it was using is now deprecated.

This PR updates the JQL call to use a new client that uses the v3 rest api. I added a TODO to eventually move all the endpoints to v3.


**Changes**

* fix(jira): use rest v3 api for JQL search

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
