### PR TITLE
Cache GitHub user profile lookups

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ jira:
 | `github.cache.collaboratorsTTL` | Collaborators cache TTL                        |
 | `github.cache.orgMembersTTL`    | Organization members cache TTL                 |
 | `github.cache.teamsTTL`         | Organization teams cache TTL                   |
+| `github.cache.userProfilesTTL`  | GitHub user profile cache TTL                  |
 | `jira.root`                     | Jira server URL                                |
 | `jira.user.login`               | Jira username                                  |
 | `jira.user.token`               | Jira API token                                 |

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -39,7 +39,7 @@ const (
 ```
 
 <a name="NewConfig"></a>
-## func [NewConfig](<https://github.com/tagoro9/fotingo/blob/main/internal/config/config.go#L106>)
+## func [NewConfig](<https://github.com/tagoro9/fotingo/blob/main/internal/config/config.go#L107>)
 
 ```go
 func NewConfig() *viper.Viper
@@ -57,7 +57,7 @@ func NewDefaultConfig() *viper.Viper
 
 
 <a name="PersistConfigValue"></a>
-## func [PersistConfigValue](<https://github.com/tagoro9/fotingo/blob/main/internal/config/config.go#L133>)
+## func [PersistConfigValue](<https://github.com/tagoro9/fotingo/blob/main/internal/config/config.go#L134>)
 
 ```go
 func PersistConfigValue(config *viper.Viper, key string, value any) error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,7 @@ func NewDefaultConfig() *viper.Viper {
 	config.SetDefault("github.cache.collaboratorsTTL", "720h")
 	config.SetDefault("github.cache.orgMembersTTL", "720h")
 	config.SetDefault("github.cache.teamsTTL", "720h")
+	config.SetDefault("github.cache.userProfilesTTL", "720h")
 	config.SetDefault("locale", i18n.DefaultLocale)
 	config.SetDefault("telemetry.enabled", true)
 	return config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,6 +80,7 @@ func (suite *ConfigTestSuite) TestNewDefaultConfig() {
 	assert.Equal(suite.T(), "720h", config.GetString("github.cache.collaboratorsTTL"))
 	assert.Equal(suite.T(), "720h", config.GetString("github.cache.orgMembersTTL"))
 	assert.Equal(suite.T(), "720h", config.GetString("github.cache.teamsTTL"))
+	assert.Equal(suite.T(), "720h", config.GetString("github.cache.userProfilesTTL"))
 	assert.True(suite.T(), config.GetBool("telemetry.enabled"))
 }
 
@@ -146,6 +147,7 @@ func (suite *ConfigTestSuite) TestNewConfig() {
 	assert.Equal(suite.T(), "720h", config.GetString("github.cache.collaboratorsTTL"))
 	assert.Equal(suite.T(), "720h", config.GetString("github.cache.orgMembersTTL"))
 	assert.Equal(suite.T(), "720h", config.GetString("github.cache.teamsTTL"))
+	assert.Equal(suite.T(), "720h", config.GetString("github.cache.userProfilesTTL"))
 	assert.True(suite.T(), config.GetBool("telemetry.enabled"))
 
 	// Verify the config file exists

--- a/internal/github/README.md
+++ b/internal/github/README.md
@@ -46,7 +46,7 @@ var ErrOAuthClientIDMissing = errors.New("github oauth client id is missing in t
 ```
 
 <a name="FetchLatestReleaseTag"></a>
-## func [FetchLatestReleaseTag](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L830>)
+## func [FetchLatestReleaseTag](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L912>)
 
 ```go
 func FetchLatestReleaseTag(ctx context.Context, client *http.Client, owner string, repo string) (string, error)
@@ -122,7 +122,7 @@ type Github interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1004>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1086>)
 
 ```go
 func New(git git.Git, cfg *viper.Viper) (Github, error)
@@ -131,7 +131,7 @@ func New(git git.Git, cfg *viper.Viper) (Github, error)
 
 
 <a name="NewAuthOnly"></a>
-### func [NewAuthOnly](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1008>)
+### func [NewAuthOnly](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1090>)
 
 ```go
 func NewAuthOnly(cfg *viper.Viper) (Github, error)
@@ -140,7 +140,7 @@ func NewAuthOnly(cfg *viper.Viper) (Github, error)
 
 
 <a name="NewAuthOnlyWithOptions"></a>
-### func [NewAuthOnlyWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1012>)
+### func [NewAuthOnlyWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1094>)
 
 ```go
 func NewAuthOnlyWithOptions(cfg *viper.Viper, allowPrompt bool) (Github, error)
@@ -149,7 +149,7 @@ func NewAuthOnlyWithOptions(cfg *viper.Viper, allowPrompt bool) (Github, error)
 
 
 <a name="NewWithHTTPClient"></a>
-### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L951>)
+### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1033>)
 
 ```go
 func NewWithHTTPClient(g git.Git, cfg *viper.Viper, httpClient *http.Client, baseURL string) (Github, error)
@@ -158,7 +158,7 @@ func NewWithHTTPClient(g git.Git, cfg *viper.Viper, httpClient *http.Client, bas
 NewWithHTTPClient returns a new GitHub client using the provided HTTP client and base URL. This bypasses OAuth authentication and is intended for testing with mock servers.
 
 <a name="NewWithHTTPClientAndRepo"></a>
-### func [NewWithHTTPClientAndRepo](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L980>)
+### func [NewWithHTTPClientAndRepo](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1062>)
 
 ```go
 func NewWithHTTPClientAndRepo(g git.Git, cfg *viper.Viper, httpClient *http.Client, baseURL, owner, repo string) (Github, error)
@@ -167,7 +167,7 @@ func NewWithHTTPClientAndRepo(g git.Git, cfg *viper.Viper, httpClient *http.Clie
 NewWithHTTPClientAndRepo creates a GitHub client with explicit owner/repo, bypassing remote URL parsing.
 
 <a name="NewWithOptions"></a>
-### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1060>)
+### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1142>)
 
 ```go
 func NewWithOptions(git git.Git, cfg *viper.Viper, allowPrompt bool) (Github, error)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -150,8 +150,14 @@ const (
 	defaultCollaboratorsCacheTTL = 720 * time.Hour
 	defaultOrgMembersCacheTTL    = 720 * time.Hour
 	defaultTeamsCacheTTL         = 720 * time.Hour
+	defaultUserProfilesCacheTTL  = 720 * time.Hour
 	maxNameLookupPerFetch        = 500
 )
+
+type cachedUserProfile struct {
+	Resolved bool `json:"resolved"`
+	User     User `json:"user"`
+}
 
 type cachedUserProfileName struct {
 	Resolved bool   `json:"resolved"`
@@ -549,7 +555,6 @@ func (g *github) enrichUsersWithProfileNames(
 			continue
 		}
 		resolvedName = strings.TrimSpace(resolvedName)
-		g.cacheUserProfileName(login, resolvedName)
 		if resolvedName == "" {
 			continue
 		}
@@ -563,11 +568,39 @@ func (g *github) enrichUsersWithProfileNames(
 }
 
 func (g *github) fetchUserProfileName(login string) (string, error) {
-	user, _, err := g.hub.Users.Get(context.Background(), login)
+	profile, err := g.fetchUserProfile(login)
 	if err != nil {
 		return "", err
 	}
-	return user.GetName(), nil
+
+	return profile.Name, nil
+}
+
+func (g *github) fetchUserProfile(login string) (User, error) {
+	trimmedLogin := strings.TrimSpace(login)
+	if trimmedLogin == "" {
+		return User{}, fmt.Errorf("login is required")
+	}
+
+	if cachedProfile, hit := g.cachedUserProfile(trimmedLogin); hit {
+		return cachedProfile, nil
+	}
+
+	user, _, err := g.hub.Users.Get(context.Background(), trimmedLogin)
+	if err != nil {
+		return User{}, err
+	}
+
+	profile := User{
+		Login: strings.TrimSpace(user.GetLogin()),
+		Name:  strings.TrimSpace(user.GetName()),
+	}
+	if profile.Login == "" {
+		profile.Login = trimmedLogin
+	}
+	g.cacheUserProfile(profile)
+
+	return profile, nil
 }
 
 // GetTeams returns organization teams for team reviewer selection.
@@ -714,32 +747,81 @@ func (g *github) metadataGlobalCacheKey(kind string) string {
 }
 
 func (g *github) metadataUserProfileCacheKey(login string) string {
-	return fmt.Sprintf("%s:%s", g.metadataGlobalCacheKey("user-profile-name"), strings.ToLower(strings.TrimSpace(login)))
+	return fmt.Sprintf("%s:%s", g.metadataGlobalCacheKey("user-profile"), normalizeMetadataLogin(login))
+}
+
+func (g *github) metadataLegacyUserProfileNameCacheKey(login string) string {
+	return fmt.Sprintf("%s:%s", g.metadataGlobalCacheKey("user-profile-name"), normalizeMetadataLogin(login))
+}
+
+func normalizeMetadataLogin(login string) string {
+	return strings.ToLower(strings.TrimSpace(login))
+}
+
+func (g *github) cachedUserProfile(login string) (User, bool) {
+	if g == nil || g.metadataCache == nil {
+		return User{}, false
+	}
+
+	trimmedLogin := strings.TrimSpace(login)
+	if trimmedLogin == "" {
+		return User{}, false
+	}
+
+	var cached cachedUserProfile
+	hit, err := g.metadataCache.Get(g.metadataUserProfileCacheKey(trimmedLogin), &cached)
+	if err == nil && hit && cached.Resolved {
+		profile := cached.User
+		if strings.TrimSpace(profile.Login) == "" {
+			profile.Login = trimmedLogin
+		}
+		profile.Name = strings.TrimSpace(profile.Name)
+		return profile, true
+	}
+
+	var legacy cachedUserProfileName
+	legacyHit, legacyErr := g.metadataCache.Get(g.metadataLegacyUserProfileNameCacheKey(trimmedLogin), &legacy)
+	if legacyErr != nil || !legacyHit || !legacy.Resolved {
+		return User{}, false
+	}
+
+	profile := User{
+		Login: trimmedLogin,
+		Name:  strings.TrimSpace(legacy.Name),
+	}
+	g.cacheUserProfile(profile)
+	return profile, true
 }
 
 func (g *github) cachedUserProfileName(login string) (string, bool) {
-	if g == nil || g.metadataCache == nil {
+	profile, hit := g.cachedUserProfile(login)
+	if !hit {
 		return "", false
 	}
 
-	var cached cachedUserProfileName
-	hit, err := g.metadataCache.Get(g.metadataUserProfileCacheKey(login), &cached)
-	if err != nil || !hit || !cached.Resolved {
-		return "", false
-	}
-
-	return cached.Name, true
+	return profile.Name, true
 }
 
-func (g *github) cacheUserProfileName(login string, name string) {
+func (g *github) cacheUserProfile(profile User) {
 	if g == nil || g.metadataCache == nil {
 		return
 	}
 
-	ttl := g.metadataTTL("cache.orgMembersTTL", defaultOrgMembersCacheTTL)
+	login := strings.TrimSpace(profile.Login)
+	if login == "" {
+		return
+	}
+
+	ttl := g.metadataTTL("cache.userProfilesTTL", defaultUserProfilesCacheTTL)
 	_ = g.metadataCache.SetWithTTL(
 		g.metadataUserProfileCacheKey(login),
-		cachedUserProfileName{Resolved: true, Name: strings.TrimSpace(name)},
+		cachedUserProfile{
+			Resolved: true,
+			User: User{
+				Login: login,
+				Name:  strings.TrimSpace(profile.Name),
+			},
+		},
 		ttl,
 	)
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -687,6 +687,7 @@ func (suite *GithubTestSuite) TestGetCollaborators_EnrichesMissingNameFromCacheH
 
 	cfg := viper.New()
 	cfg.Set("github.cache.collaboratorsTTL", "1h")
+	cfg.Set("github.cache.userProfilesTTL", "1h")
 	suite.client.ViperConfigurableService = &config.ViperConfigurableService{Config: cfg, Prefix: "github"}
 	suite.client.metadataCache = store
 	suite.client.cacheInitErr = nil
@@ -701,7 +702,10 @@ func (suite *GithubTestSuite) TestGetCollaborators_EnrichesMissingNameFromCacheH
 	}, time.Hour))
 	assert.NoError(suite.T(), store.SetWithTTL(suite.client.metadataUserProfileCacheKey("yprk"), map[string]any{
 		"resolved": true,
-		"name":     "YoungJun Park",
+		"user": map[string]any{
+			"login": "yprk",
+			"name":  "YoungJun Park",
+		},
 	}, time.Hour))
 
 	collaboratorListCalls := 0
@@ -737,6 +741,65 @@ func (suite *GithubTestSuite) TestGetCollaborators_EnrichesMissingNameFromCacheH
 	assert.NotContains(suite.T(), strings.ToLower(string(entries[0].Value)), "avatar")
 }
 
+func (suite *GithubTestSuite) TestGetCollaborators_EnrichesMissingNameFromLegacyCacheHit() {
+	store, err := cache.New(cache.WithPath(filepath.Join(suite.T().TempDir(), "cache.db")), cache.WithLogger(nil))
+	assert.NoError(suite.T(), err)
+	defer func() { _ = store.Close() }()
+
+	cfg := viper.New()
+	cfg.Set("github.cache.collaboratorsTTL", "1h")
+	cfg.Set("github.cache.userProfilesTTL", "1h")
+	suite.client.ViperConfigurableService = &config.ViperConfigurableService{Config: cfg, Prefix: "github"}
+	suite.client.metadataCache = store
+	suite.client.cacheInitErr = nil
+
+	cacheKey := suite.client.metadataCacheKey("collaborators")
+	assert.NoError(suite.T(), store.SetWithTTL(cacheKey, []map[string]any{
+		{
+			"login":      "yprk",
+			"name":       "",
+			"avatar_url": "https://avatars.githubusercontent.com/u/1",
+		},
+	}, time.Hour))
+	assert.NoError(suite.T(), store.SetWithTTL(suite.client.metadataLegacyUserProfileNameCacheKey("yprk"), map[string]any{
+		"resolved": true,
+		"name":     "YoungJun Park",
+	}, time.Hour))
+
+	collaboratorListCalls := 0
+	profileLookupCalls := 0
+	suite.setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/repos/testowner/testrepo/collaborators" && r.Method == http.MethodGet:
+			collaboratorListCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		case r.URL.Path == "/api/v3/users/yprk" && r.Method == http.MethodGet:
+			profileLookupCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockUser("yprk", "YoungJun Park", "https://avatars.githubusercontent.com/u/1"))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	collaborators, err := suite.client.GetCollaborators()
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), collaborators, 1)
+	assert.Equal(suite.T(), "yprk", collaborators[0].Login)
+	assert.Equal(suite.T(), "YoungJun Park", collaborators[0].Name)
+	assert.Equal(suite.T(), 0, collaboratorListCalls)
+	assert.Equal(suite.T(), 0, profileLookupCalls)
+
+	var cachedProfile map[string]any
+	hit, err := store.Get(suite.client.metadataUserProfileCacheKey("yprk"), &cachedProfile)
+	assert.NoError(suite.T(), err)
+	assert.True(suite.T(), hit)
+	assert.Equal(suite.T(), true, cachedProfile["resolved"])
+}
+
 func (suite *GithubTestSuite) TestGetOrgMembers_EnrichesMissingNameFromCacheHit() {
 	store, err := cache.New(cache.WithPath(filepath.Join(suite.T().TempDir(), "cache.db")), cache.WithLogger(nil))
 	assert.NoError(suite.T(), err)
@@ -744,6 +807,7 @@ func (suite *GithubTestSuite) TestGetOrgMembers_EnrichesMissingNameFromCacheHit(
 
 	cfg := viper.New()
 	cfg.Set("github.cache.orgMembersTTL", "1h")
+	cfg.Set("github.cache.userProfilesTTL", "1h")
 	suite.client.ViperConfigurableService = &config.ViperConfigurableService{Config: cfg, Prefix: "github"}
 	suite.client.metadataCache = store
 	suite.client.cacheInitErr = nil
@@ -758,7 +822,10 @@ func (suite *GithubTestSuite) TestGetOrgMembers_EnrichesMissingNameFromCacheHit(
 	}, time.Hour))
 	assert.NoError(suite.T(), store.SetWithTTL(suite.client.metadataUserProfileCacheKey("yprk"), map[string]any{
 		"resolved": true,
-		"name":     "YoungJun Park",
+		"user": map[string]any{
+			"login": "yprk",
+			"name":  "YoungJun Park",
+		},
 	}, time.Hour))
 
 	orgMemberListCalls := 0
@@ -792,6 +859,65 @@ func (suite *GithubTestSuite) TestGetOrgMembers_EnrichesMissingNameFromCacheHit(
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), entries, 1)
 	assert.NotContains(suite.T(), strings.ToLower(string(entries[0].Value)), "avatar")
+}
+
+func (suite *GithubTestSuite) TestGetOrgMembers_EnrichesMissingNameFromLegacyCacheHit() {
+	store, err := cache.New(cache.WithPath(filepath.Join(suite.T().TempDir(), "cache.db")), cache.WithLogger(nil))
+	assert.NoError(suite.T(), err)
+	defer func() { _ = store.Close() }()
+
+	cfg := viper.New()
+	cfg.Set("github.cache.orgMembersTTL", "1h")
+	cfg.Set("github.cache.userProfilesTTL", "1h")
+	suite.client.ViperConfigurableService = &config.ViperConfigurableService{Config: cfg, Prefix: "github"}
+	suite.client.metadataCache = store
+	suite.client.cacheInitErr = nil
+
+	cacheKey := suite.client.metadataOwnerCacheKey("org-members")
+	assert.NoError(suite.T(), store.SetWithTTL(cacheKey, []map[string]any{
+		{
+			"login":      "yprk",
+			"name":       "",
+			"avatar_url": "https://avatars.githubusercontent.com/u/1",
+		},
+	}, time.Hour))
+	assert.NoError(suite.T(), store.SetWithTTL(suite.client.metadataLegacyUserProfileNameCacheKey("yprk"), map[string]any{
+		"resolved": true,
+		"name":     "YoungJun Park",
+	}, time.Hour))
+
+	orgMemberListCalls := 0
+	profileLookupCalls := 0
+	suite.setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/orgs/testowner/members" && r.Method == http.MethodGet:
+			orgMemberListCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		case r.URL.Path == "/api/v3/users/yprk" && r.Method == http.MethodGet:
+			profileLookupCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockUser("yprk", "YoungJun Park", "https://avatars.githubusercontent.com/u/1"))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	members, err := suite.client.GetOrgMembers()
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), members, 1)
+	assert.Equal(suite.T(), "yprk", members[0].Login)
+	assert.Equal(suite.T(), "YoungJun Park", members[0].Name)
+	assert.Equal(suite.T(), 0, orgMemberListCalls)
+	assert.Equal(suite.T(), 0, profileLookupCalls)
+
+	var cachedProfile map[string]any
+	hit, err := store.Get(suite.client.metadataUserProfileCacheKey("yprk"), &cachedProfile)
+	assert.NoError(suite.T(), err)
+	assert.True(suite.T(), hit)
+	assert.Equal(suite.T(), true, cachedProfile["resolved"])
 }
 
 func (suite *GithubTestSuite) TestGetOrgMembers_LimitsColdFetchProfileLookups() {
@@ -912,6 +1038,55 @@ func (suite *GithubTestSuite) TestGetOrgMembers_DefaultCacheTTLIsThirtyDays() {
 	expectedTTL := 30 * 24 * time.Hour
 	assert.GreaterOrEqual(suite.T(), ttl, expectedTTL-time.Hour)
 	assert.LessOrEqual(suite.T(), ttl, expectedTTL+time.Hour)
+}
+
+func (suite *GithubTestSuite) TestGetCollaborators_CachesFetchedUserProfilesWithConfiguredTTL() {
+	store, err := cache.New(cache.WithPath(filepath.Join(suite.T().TempDir(), "cache.db")), cache.WithLogger(nil))
+	assert.NoError(suite.T(), err)
+	defer func() { _ = store.Close() }()
+
+	cfg := viper.New()
+	cfg.Set("github.cache.collaboratorsTTL", "1h")
+	cfg.Set("github.cache.userProfilesTTL", "2h")
+	suite.client.ViperConfigurableService = &config.ViperConfigurableService{Config: cfg, Prefix: "github"}
+	suite.client.metadataCache = store
+	suite.client.cacheInitErr = nil
+
+	suite.setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/repos/testowner/testrepo/collaborators" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"login":      "yprk",
+					"name":       "",
+					"avatar_url": "https://avatars.githubusercontent.com/u/1",
+				},
+			})
+			return
+		case r.URL.Path == "/api/v3/users/yprk" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockUser("yprk", "YoungJun Park", "https://avatars.githubusercontent.com/u/1"))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	start := time.Now().UTC()
+	collaborators, err := suite.client.GetCollaborators()
+	assert.NoError(suite.T(), err)
+	require.Len(suite.T(), collaborators, 1)
+
+	entries, err := store.List(suite.client.metadataUserProfileCacheKey("yprk"))
+	assert.NoError(suite.T(), err)
+	require.Len(suite.T(), entries, 1)
+	require.NotNil(suite.T(), entries[0].ExpiresAt)
+
+	ttl := entries[0].ExpiresAt.Sub(start)
+	expectedTTL := 2 * time.Hour
+	assert.GreaterOrEqual(suite.T(), ttl, expectedTTL-time.Minute)
+	assert.LessOrEqual(suite.T(), ttl, expectedTTL+time.Minute)
 }
 
 func (suite *GithubTestSuite) TestGetOrgMembers_ReusesOwnerScopedCacheAcrossRepos() {

--- a/pkg/commands/config_keys.go
+++ b/pkg/commands/config_keys.go
@@ -45,6 +45,11 @@ var configKeySpecs = []configKeySpec{
 		ValueType:   configValueTypeDuration,
 		Description: "TTL for GitHub teams cache",
 	},
+	{
+		Key:         "github.cache.userProfilesTTL",
+		ValueType:   configValueTypeDuration,
+		Description: "TTL for GitHub user profile cache",
+	},
 	{Key: "github.releaseTemplate", ValueType: configValueTypeString, Description: "Release body template"},
 	{Key: "github.token", ValueType: configValueTypeString, Description: "GitHub token (OAuth or PAT)", Sensitive: true},
 	{

--- a/pkg/commands/config_keys_test.go
+++ b/pkg/commands/config_keys_test.go
@@ -21,6 +21,15 @@ func TestLookupConfigKeySpec(t *testing.T) {
 	assert.False(t, spec.Sensitive)
 }
 
+func TestLookupConfigKeySpec_GitHubUserProfilesTTL(t *testing.T) {
+	t.Parallel()
+
+	spec, ok := lookupConfigKeySpec("github.cache.userProfilesTTL")
+	require.True(t, ok)
+	assert.Equal(t, configValueTypeDuration, spec.ValueType)
+	assert.Equal(t, "TTL for GitHub user profile cache", spec.Description)
+}
+
 func TestParseConfigKeyValue_Duration(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Summary**

Cache GitHub user profile lookups

**Description**

Why: GitHub profile lookups are called repeatedly during participant enrichment.

What changed:
- cache GitHub user profiles by login with a dedicated TTL
- reuse legacy name-only cache entries as a fallback
- expose github.cache.userProfilesTTL and document it
- add config and GitHub cache coverage

Testing:
- go test ./internal/github ./internal/config ./pkg/commands



**Changes**

* fix(github): cache user profile lookups (+299/-24)

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)