### PR TITLE
fix: doing fetch in large repos takes a long long time

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ fotingo review sync --section changes --section fixed-issues -y
 fotingo open pr
 ```
 
+`fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
+
 For full authentication setup details, see [docs/authentication.md](./docs/authentication.md).
 
 ## Common Commands

--- a/docs/automation-and-json.md
+++ b/docs/automation-and-json.md
@@ -24,6 +24,7 @@ fotingo inspect pr --json
 ```
 
 When `start` runs with `--worktree`, `--worktree-path`, or `git.worktree.enabled=true`, automation should read both `branch.name` and `branch.worktreePath` from the JSON result.
+`start` auto-stashes only tracked or staged changes; untracked-only files and directories remain untouched.
 
 ## Recommended Flags for Automation
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,6 +108,7 @@ Notes:
 
 - In worktree mode, `start` prints the created branch name and worktree folder, and JSON output includes `branch.name` plus `branch.worktreePath`.
 - Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
+- `start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
 - `--worktree-path` implies worktree mode and overrides `git.worktree.path` for one invocation.
 
 ### `review`

--- a/internal/commands/ai/skills.go
+++ b/internal/commands/ai/skills.go
@@ -13,7 +13,7 @@ var skillsFS embed.FS
 
 // skillMetadataVersion is the semver for generated fotingo skill content.
 // Bump this when generated skill guidance/frontmatter changes.
-const skillMetadataVersion = "1.12.0"
+const skillMetadataVersion = "1.13.1"
 
 // RenderSkill returns provider-specific skill markdown content from embedded assets.
 func RenderSkill(provider Provider) (string, error) {

--- a/internal/commands/ai/skills/fotingo-core.md
+++ b/internal/commands/ai/skills/fotingo-core.md
@@ -126,6 +126,7 @@ Rebase stack branches in their existing local worktrees:
 - Use `fotingo inspect pr --json` when you need pull request discussion context before editing, syncing, or responding to review feedback.
 - Use `fotingo start ... -y` to begin work from an existing issue or a newly created issue.
 - Use `fotingo start --worktree-path <parent> ... --json` when you want an isolated checkout under a specific parent; automation should read `branch.name` and `branch.worktreePath` from the JSON result. Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
+- `fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
 - Prefer non-interactive flags (`-y`, `--json`) in automated runs.
 - Use explicit flags rather than prompts in non-interactive environments.
 - For reviewers, assignees, and labels, run `fotingo search ... --json` first and pass the resolved values into `fotingo review`.

--- a/internal/commands/ai/testdata/skill_codex.golden
+++ b/internal/commands/ai/testdata/skill_codex.golden
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires fotingo CLI.
 metadata:
   author: fotingo
-  version: "1.12.0"
+  version: "1.13.1"
   generatedBy: "dev"
 ---
 
@@ -141,6 +141,7 @@ fotingo review stacks rebase --json
 - Use `fotingo inspect pr --json` when you need pull request discussion context before editing, syncing, or responding to review feedback.
 - Use `fotingo start ... -y` to begin work from an existing issue or a newly created issue.
 - Use `fotingo start --worktree-path <parent> ... --json` when you want an isolated checkout under a specific parent; automation should read `branch.name` and `branch.worktreePath` from the JSON result. Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
+- `fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
 - Prefer non-interactive flags (`-y`, `--json`) in automated runs.
 - Use explicit flags rather than prompts in non-interactive environments.
 - For reviewers, assignees, and labels, run `fotingo search ... --json` first and pass the resolved values into `fotingo review`.

--- a/internal/commands/ai/testdata/skill_cursor.golden
+++ b/internal/commands/ai/testdata/skill_cursor.golden
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires fotingo CLI.
 metadata:
   author: fotingo
-  version: "1.12.0"
+  version: "1.13.1"
   generatedBy: "dev"
 ---
 
@@ -141,6 +141,7 @@ fotingo review stacks rebase --json
 - Use `fotingo inspect pr --json` when you need pull request discussion context before editing, syncing, or responding to review feedback.
 - Use `fotingo start ... -y` to begin work from an existing issue or a newly created issue.
 - Use `fotingo start --worktree-path <parent> ... --json` when you want an isolated checkout under a specific parent; automation should read `branch.name` and `branch.worktreePath` from the JSON result. Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
+- `fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
 - Prefer non-interactive flags (`-y`, `--json`) in automated runs.
 - Use explicit flags rather than prompts in non-interactive environments.
 - For reviewers, assignees, and labels, run `fotingo search ... --json` first and pass the resolved values into `fotingo review`.

--- a/internal/commands/inspect/workflow_test.go
+++ b/internal/commands/inspect/workflow_test.go
@@ -69,6 +69,10 @@ func (s *inspectGitStub) HasUncommittedChanges() (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }
 
+func (s *inspectGitStub) HasStashableChanges() (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
 func (s *inspectGitStub) GetCommitsSince(string) ([]git.Commit, error) {
 	s.commitsSinceCalls++
 	return nil, fmt.Errorf("unexpected call")

--- a/internal/commands/review/workflow_test.go
+++ b/internal/commands/review/workflow_test.go
@@ -143,6 +143,9 @@ func (workflowSuccessMockGit) PopStash() error { return nil }
 func (workflowSuccessMockGit) HasUncommittedChanges() (bool, error) {
 	return false, nil
 }
+func (workflowSuccessMockGit) HasStashableChanges() (bool, error) {
+	return false, nil
+}
 func (workflowSuccessMockGit) GetCommitsSince(string) ([]git.Commit, error) {
 	return nil, nil
 }

--- a/internal/commands/start/workflow.go
+++ b/internal/commands/start/workflow.go
@@ -181,7 +181,7 @@ func (r WorkflowRunner) RunWithResult(cmd *cobra.Command, statusCh *chan string,
 
 	out.Verbose(i18n.StartStatusCheckChanges)
 	checkChangesStart := time.Now()
-	hasChanges, err := gitClient.HasUncommittedChanges()
+	hasChanges, err := gitClient.HasStashableChanges()
 	logStartPhaseTiming(out, "check_uncommitted_changes", checkChangesStart)
 	if err != nil {
 		result.Err = fterrors.WrapGitError(t(i18n.StartWrapCheckChanges), err)
@@ -338,7 +338,7 @@ func (r WorkflowRunner) progressStartWorkflow(jiraClient jira.Jira, issue *jira.
 
 		out.Verbose(i18n.StartStatusCheckChanges)
 		checkChangesStart := time.Now()
-		hasChanges, err := gitClient.HasUncommittedChanges()
+		hasChanges, err := gitClient.HasStashableChanges()
 		logStartPhaseTiming(out, "check_uncommitted_changes", checkChangesStart)
 		if err != nil {
 			return fterrors.WrapGitError(r.localize(i18n.StartWrapCheckChanges), err)

--- a/internal/commands/start/workflow_test.go
+++ b/internal/commands/start/workflow_test.go
@@ -115,6 +115,7 @@ type workflowMockGit struct {
 	createBranchName      string
 	createWorktreePath    string
 	createWorktreeOptions git.WorktreeOptions
+	hasStashableChanges   bool
 	fetchDefaultCalls     int
 	createBranchCalls     int
 	createWorktreeCalls   int
@@ -147,6 +148,10 @@ func (m *workflowMockGit) PopStash() error {
 func (m *workflowMockGit) HasUncommittedChanges() (bool, error) {
 	m.hasUncommitedCalls++
 	return false, nil
+}
+func (m *workflowMockGit) HasStashableChanges() (bool, error) {
+	m.hasUncommitedCalls++
+	return m.hasStashableChanges, nil
 }
 func (m *workflowMockGit) GetCommitsSince(string) ([]git.Commit, error) {
 	return nil, nil
@@ -290,6 +295,47 @@ func TestWorkflowRunnerProgressStartWorkflow_WaitsForGitDebugForwarding(t *testi
 		t.Fatal("timed out waiting for workflow to finish")
 	}
 
+	assert.Equal(t, 1, gitClient.fetchDefaultCalls)
+	assert.Equal(t, 1, gitClient.createBranchCalls)
+	assert.Equal(t, 1, gitClient.hasUncommitedCalls)
+}
+
+func TestWorkflowRunnerProgressStartWorkflow_IgnoresUntrackedOnlyState(t *testing.T) {
+	gitClient := &workflowMockGit{createBranchName: "f/test-123_fix_worktree"}
+	jiraClient := &workflowMockJira{
+		setIssue: &jira.Issue{
+			Key:     "TEST-123",
+			Summary: "Fix worktree start flow",
+			Type:    "Task",
+			Status:  string(jira.StatusInProgress),
+		},
+	}
+	stashCalls := 0
+
+	runner := WorkflowRunner{
+		Config: viper.New(),
+		Deps: WorkflowDeps{
+			RunWithSpinner: func(work func(WorkflowEmitter) error) error {
+				return work(&startCollectingEmitter{})
+			},
+			ResolveIssueAssignee: func(WorkflowEmitter, jira.Jira, string) {},
+			NewGitClient: func(_ *viper.Viper, _ *chan string) (git.Git, error) {
+				return gitClient, nil
+			},
+			StashChanges: func(WorkflowEmitter, git.Git) error {
+				stashCalls++
+				return nil
+			},
+		},
+	}
+
+	err := runner.progressStartWorkflow(
+		jiraClient,
+		&jira.Issue{Key: "TEST-123", Summary: "Fix worktree start flow", Type: "Task"},
+		"TEST-123",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stashCalls)
 	assert.Equal(t, 1, gitClient.fetchDefaultCalls)
 	assert.Equal(t, 1, gitClient.createBranchCalls)
 	assert.Equal(t, 1, gitClient.hasUncommitedCalls)

--- a/internal/git/README.md
+++ b/internal/git/README.md
@@ -59,7 +59,7 @@ type Commit struct {
 ```
 
 <a name="CredentialProvider"></a>
-## type [CredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L95-L97>)
+## type [CredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L97-L99>)
 
 CredentialProvider abstracts git credential retrieval for testability.
 
@@ -70,7 +70,7 @@ type CredentialProvider interface {
 ```
 
 <a name="Git"></a>
-## type [Git](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L46-L78>)
+## type [Git](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L46-L80>)
 
 
 
@@ -95,6 +95,8 @@ type Git interface {
     PopStash() error
     // HasUncommittedChanges checks if there are uncommitted changes (staged or unstaged)
     HasUncommittedChanges() (bool, error)
+    // HasStashableChanges checks whether tracked or staged changes require start's auto-stash flow.
+    HasStashableChanges() (bool, error)
     // GetCommitsSince returns commits since the given reference
     GetCommitsSince(ref string) ([]Commit, error)
     // DoesBranchExistInRemote checks if a branch exists on the remote
@@ -111,7 +113,7 @@ type Git interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1618>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1670>)
 
 ```go
 func New(cfg *viper.Viper, messages *chan string) (Git, error)
@@ -120,7 +122,7 @@ func New(cfg *viper.Viper, messages *chan string) (Git, error)
 New returns a new instance of a Git client in the current working directory. It supports linked worktrees and keeps credential helper lookups rooted at the active worktree, including repositories that enable extensions.worktreeConfig.
 
 <a name="NewWithCredentialProvider"></a>
-### func [NewWithCredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1650>)
+### func [NewWithCredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1702>)
 
 ```go
 func NewWithCredentialProvider(cfg *viper.Viper, messages *chan string, cp CredentialProvider) (Git, error)
@@ -129,7 +131,7 @@ func NewWithCredentialProvider(cfg *viper.Viper, messages *chan string, cp Crede
 NewWithCredentialProvider returns a new Git client with a custom credential provider. This is useful for testing functions that require credentials without invoking git credential fill.
 
 <a name="RemoteConfigurable"></a>
-## type [RemoteConfigurable](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L102-L104>)
+## type [RemoteConfigurable](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L104-L106>)
 
 RemoteConfigurable allows reconfiguring a remote URL on a Git client. This is used in tests to point the remote to a local bare repo for operations while keeping the original URL for display purposes.
 
@@ -140,7 +142,7 @@ type RemoteConfigurable interface {
 ```
 
 <a name="TemplateIssue"></a>
-## type [TemplateIssue](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L197-L202>)
+## type [TemplateIssue](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L199-L204>)
 
 TODO Is this needed now that we have the issue struct?
 
@@ -154,7 +156,7 @@ type TemplateIssue struct {
 ```
 
 <a name="WorktreeInfo"></a>
-## type [WorktreeInfo](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L87-L90>)
+## type [WorktreeInfo](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L89-L92>)
 
 WorktreeInfo describes a local git worktree.
 
@@ -166,7 +168,7 @@ type WorktreeInfo struct {
 ```
 
 <a name="WorktreeOptions"></a>
-## type [WorktreeOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L81-L84>)
+## type [WorktreeOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L83-L86>)
 
 WorktreeOptions controls where linked worktrees are created.
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -63,6 +63,8 @@ type Git interface {
 	PopStash() error
 	// HasUncommittedChanges checks if there are uncommitted changes (staged or unstaged)
 	HasUncommittedChanges() (bool, error)
+	// HasStashableChanges checks whether tracked or staged changes require start's auto-stash flow.
+	HasStashableChanges() (bool, error)
 	// GetCommitsSince returns commits since the given reference
 	GetCommitsSince(ref string) ([]Commit, error)
 	// DoesBranchExistInRemote checks if a branch exists on the remote
@@ -905,9 +907,35 @@ func (g *git) FetchDefaultBranch() error {
 		return fmt.Errorf("failed to get default branch: %w", err)
 	}
 
-	remote := g.GetConfigString("remote")
+	worktreeRoot, err := g.worktreeRoot()
+	if err != nil {
+		return err
+	}
+
+	remote := strings.TrimSpace(g.GetConfigString("remote"))
+	if remote == "" {
+		return fmt.Errorf("git remote is not configured")
+	}
+
 	(*g.messages) <- fmt.Sprintf("Fetching from remote %s", remote)
-	if err := g.fetch(remote); err != nil {
+	refspec := fmt.Sprintf(
+		"refs/heads/%s:refs/remotes/%s/%s",
+		defaultBranch,
+		remote,
+		defaultBranch,
+	)
+	_, stderr, err := execGitCommand(
+		worktreeRoot,
+		gitNonInteractiveEnv(),
+		"fetch",
+		"--depth=1",
+		remote,
+		refspec,
+	)
+	if err != nil {
+		if stderr != "" {
+			return fmt.Errorf("failed to fetch from remote: %s", stderr)
+		}
 		return fmt.Errorf("failed to fetch from remote: %w", err)
 	}
 
@@ -1197,6 +1225,30 @@ func (g *git) HasUncommittedChanges() (bool, error) {
 	}
 
 	return false, nil
+}
+
+// HasStashableChanges reports whether tracked or staged changes should trigger start auto-stash.
+func (g *git) HasStashableChanges() (bool, error) {
+	worktreeRoot, err := g.worktreeRoot()
+	if err != nil {
+		return false, err
+	}
+
+	stdout, stderr, err := execGitCommand(
+		worktreeRoot,
+		gitNonInteractiveEnv(),
+		"status",
+		"--porcelain",
+		"--untracked-files=no",
+	)
+	if err != nil {
+		if stderr != "" {
+			return false, fmt.Errorf("failed to get worktree status: %s", stderr)
+		}
+		return false, fmt.Errorf("failed to get worktree status: %w", err)
+	}
+
+	return strings.TrimSpace(stdout) != "", nil
 }
 
 func (g *git) loadGlobalIgnoreMatcher() (gitignore.Matcher, error) {

--- a/internal/git/git_fs_test.go
+++ b/internal/git/git_fs_test.go
@@ -551,6 +551,45 @@ func (s *GitFsTestSuite) TestHasUncommittedChanges_WithGlobalIgnoreAndNonIgnored
 	assert.True(t, hasChanges)
 }
 
+func (s *GitFsTestSuite) TestHasStashableChanges_IgnoresUntrackedOnlyState() {
+	t := s.T()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(s.repoDir(), ".codex"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(s.repoDir(), "openspec"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(s.repoDir(), ".codex", "notes.md"), []byte("local notes"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(s.repoDir(), "openspec", "proposal.md"), []byte("draft spec"), 0644))
+
+	hasChanges, err := s.gitClient.HasStashableChanges()
+	assert.NoError(t, err)
+	assert.False(t, hasChanges)
+}
+
+func (s *GitFsTestSuite) TestHasStashableChanges_DetectsTrackedChanges() {
+	t := s.T()
+
+	require.NoError(t, os.WriteFile(filepath.Join(s.repoDir(), "dummy.txt"), []byte("modified"), 0644))
+
+	hasChanges, err := s.gitClient.HasStashableChanges()
+	assert.NoError(t, err)
+	assert.True(t, hasChanges)
+}
+
+func (s *GitFsTestSuite) TestHasStashableChanges_DetectsStagedChanges() {
+	t := s.T()
+
+	wt, err := s.repo.Worktree()
+	require.NoError(t, err)
+
+	filePath := filepath.Join(s.repoDir(), "staged-only.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("staged"), 0644))
+	_, err = wt.Add("staged-only.txt")
+	require.NoError(t, err)
+
+	hasChanges, err := s.gitClient.HasStashableChanges()
+	assert.NoError(t, err)
+	assert.True(t, hasChanges)
+}
+
 func (s *GitFsTestSuite) configureGlobalIgnore(patterns string) {
 	t := s.T()
 
@@ -737,8 +776,10 @@ func TestFetchDefaultBranch_UsesGitRemoteFallbackWhenRepoRemoteIsMissing(t *test
 	runGitCommand(t, targetDir, "add", "LOCAL.md")
 	runGitCommand(t, targetDir, "commit", "--no-verify", "-m", "feat: local repo")
 	runGitCommand(t, targetDir, "branch", "-M", "main")
+	runGitCommand(t, targetDir, "remote", "add", "origin", "file://"+bareDir)
 
 	originalExecGitCommand := execGitCommand
+	var capturedFetchArgs []string
 	defer func() {
 		execGitCommand = originalExecGitCommand
 	}()
@@ -753,6 +794,9 @@ func TestFetchDefaultBranch_UsesGitRemoteFallbackWhenRepoRemoteIsMissing(t *test
 		case "remote get-url origin":
 			return "file://" + bareDir, "", nil
 		default:
+			if len(args) > 0 && args[0] == "fetch" {
+				capturedFetchArgs = append([]string{}, args...)
+			}
 			return originalExecGitCommand(dir, env, args...)
 		}
 	}
@@ -773,6 +817,16 @@ func TestFetchDefaultBranch_UsesGitRemoteFallbackWhenRepoRemoteIsMissing(t *test
 	remoteMain := plumbing.NewRemoteReferenceName("origin", "main")
 	_, err = internalGit.repo.Reference(remoteMain, true)
 	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{
+			"fetch",
+			"--depth=1",
+			"origin",
+			"refs/heads/main:refs/remotes/origin/main",
+		},
+		capturedFetchArgs,
+	)
 }
 
 func runGitCommand(t *testing.T, dir string, args ...string) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -74,6 +74,10 @@ func (m *mockGit) HasUncommittedChanges() (bool, error) {
 	return false, nil
 }
 
+func (m *mockGit) HasStashableChanges() (bool, error) {
+	return false, nil
+}
+
 func (m *mockGit) GetCommitsSince(_ string) ([]git.Commit, error) {
 	return nil, nil
 }

--- a/pkg/commands/open_test.go
+++ b/pkg/commands/open_test.go
@@ -37,6 +37,8 @@ type mockGit struct {
 	remoteErr         error
 	hasChanges        bool
 	hasChangesErr     error
+	hasStashable      *bool
+	hasStashableErr   error
 	stashErr          error
 	stashCalls        int
 	stashMessage      string
@@ -93,6 +95,16 @@ func (m *mockGit) PopStash() error {
 }
 
 func (m *mockGit) HasUncommittedChanges() (bool, error) {
+	return m.hasChanges, m.hasChangesErr
+}
+
+func (m *mockGit) HasStashableChanges() (bool, error) {
+	if m.hasStashableErr != nil {
+		return false, m.hasStashableErr
+	}
+	if m.hasStashable != nil {
+		return *m.hasStashable, nil
+	}
 	return m.hasChanges, m.hasChangesErr
 }
 

--- a/pkg/commands/start_test.go
+++ b/pkg/commands/start_test.go
@@ -928,6 +928,56 @@ func TestRunStartWithResult_AutoStashesWhenChangesExist(t *testing.T) {
 	assert.Equal(t, 1, g.createBranchCalls)
 }
 
+func TestRunStartWithResult_DoesNotAutoStashForUntrackedOnlyState(t *testing.T) {
+	origFlags := startCmdFlags
+	origNewJiraClient := newJiraClient
+	origNewGitClient := newGitClient
+	defer func() {
+		startCmdFlags = origFlags
+		newJiraClient = origNewJiraClient
+		newGitClient = origNewGitClient
+	}()
+
+	startCmdFlags = startFlags{}
+	j := &mockJira{
+		trackerIssue: &tracker.Issue{
+			Key: "TEST-123",
+		},
+		currentUser: &tracker.User{
+			ID:   "user-1",
+			Name: "Jane Doe",
+		},
+		setJiraIssueStatus: &jira.Issue{
+			Key:     "TEST-123",
+			Summary: "Ignore untracked-only state",
+			Status:  string(jira.StatusInProgress),
+			Type:    "Task",
+		},
+	}
+	stashable := false
+	g := &mockGit{
+		hasChanges:       true,
+		hasStashable:     &stashable,
+		createBranchName: "f/test-123_ignore_untracked_only_state",
+	}
+
+	newJiraClient = func(_ *viper.Viper) (jira.Jira, error) {
+		return j, nil
+	}
+	newGitClient = func(_ *viper.Viper, _ *chan string) (git.Git, error) {
+		return g, nil
+	}
+
+	statusCh := make(chan string, 32)
+	defer close(statusCh)
+
+	cmd := newStartFlagProbeCommand(t)
+	result := runStartWithResult(cmd, &statusCh, "TEST-123")
+	require.NoError(t, result.err)
+	assert.Equal(t, 0, g.stashCalls)
+	assert.Equal(t, 1, g.createBranchCalls)
+}
+
 func TestRunStartWithResult_ReturnsErrorWhenAutoStashFails(t *testing.T) {
 	origFlags := startCmdFlags
 	origNewJiraClient := newJiraClient


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Tighten start preflight for fetch and auto-stash
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->

What changed:
- refresh only the configured remote default branch tip with a targeted shallow fetch
- auto-stash only when tracked or staged changes are present during start
- add regression coverage for targeted fetch and tracked-vs-untracked stash detection
- update start docs and generated AI workflow guidance
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix(start): avoid stashing untracked-only worktrees (+239/-7)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
