### PR TITLE
[FOTINGO-43] Fotingo fetch with depth=0 creates a shallow version of a clone, breaking other things

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fotingo review sync --section changes --section fixed-issues -y
 fotingo open pr
 ```
 
-`fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
+`fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place. When branch creation needs a base refresh, fotingo checks only the default branch and does not use shallow fetches during that preflight step.
 
 For full authentication setup details, see [docs/authentication.md](./docs/authentication.md).
 

--- a/docs/automation-and-json.md
+++ b/docs/automation-and-json.md
@@ -25,6 +25,7 @@ fotingo inspect pr --json
 
 When `start` runs with `--worktree`, `--worktree-path`, or `git.worktree.enabled=true`, automation should read both `branch.name` and `branch.worktreePath` from the JSON result.
 `start` auto-stashes only tracked or staged changes; untracked-only files and directories remain untouched.
+`start` refreshes only the default branch when needed and avoids shallow-fetch side effects during that preflight step.
 
 ## Recommended Flags for Automation
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -109,6 +109,7 @@ Notes:
 - In worktree mode, `start` prints the created branch name and worktree folder, and JSON output includes `branch.name` plus `branch.worktreePath`.
 - Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
 - `start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
+- `start` resolves and refreshes only the repository default branch during branch preflight. If the local remote-tracking ref is already current, fotingo skips the fetch; when a refresh is needed, it uses a targeted non-shallow fetch.
 - `--worktree-path` implies worktree mode and overrides `git.worktree.path` for one invocation.
 
 ### `review`

--- a/internal/commands/ai/skills.go
+++ b/internal/commands/ai/skills.go
@@ -13,7 +13,7 @@ var skillsFS embed.FS
 
 // skillMetadataVersion is the semver for generated fotingo skill content.
 // Bump this when generated skill guidance/frontmatter changes.
-const skillMetadataVersion = "1.13.1"
+const skillMetadataVersion = "1.14.0"
 
 // RenderSkill returns provider-specific skill markdown content from embedded assets.
 func RenderSkill(provider Provider) (string, error) {

--- a/internal/commands/ai/skills/fotingo-core.md
+++ b/internal/commands/ai/skills/fotingo-core.md
@@ -127,6 +127,7 @@ Rebase stack branches in their existing local worktrees:
 - Use `fotingo start ... -y` to begin work from an existing issue or a newly created issue.
 - Use `fotingo start --worktree-path <parent> ... --json` when you want an isolated checkout under a specific parent; automation should read `branch.name` and `branch.worktreePath` from the JSON result. Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
 - `fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
+- `fotingo start` refreshes only the default branch during branch preflight, skips the fetch when the local tracking ref is already current, and does not use shallow fetches for that refresh.
 - Prefer non-interactive flags (`-y`, `--json`) in automated runs.
 - Use explicit flags rather than prompts in non-interactive environments.
 - For reviewers, assignees, and labels, run `fotingo search ... --json` first and pass the resolved values into `fotingo review`.

--- a/internal/commands/ai/testdata/skill_codex.golden
+++ b/internal/commands/ai/testdata/skill_codex.golden
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires fotingo CLI.
 metadata:
   author: fotingo
-  version: "1.13.1"
+  version: "1.14.0"
   generatedBy: "dev"
 ---
 
@@ -142,6 +142,7 @@ fotingo review stacks rebase --json
 - Use `fotingo start ... -y` to begin work from an existing issue or a newly created issue.
 - Use `fotingo start --worktree-path <parent> ... --json` when you want an isolated checkout under a specific parent; automation should read `branch.name` and `branch.worktreePath` from the JSON result. Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
 - `fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
+- `fotingo start` refreshes only the default branch during branch preflight, skips the fetch when the local tracking ref is already current, and does not use shallow fetches for that refresh.
 - Prefer non-interactive flags (`-y`, `--json`) in automated runs.
 - Use explicit flags rather than prompts in non-interactive environments.
 - For reviewers, assignees, and labels, run `fotingo search ... --json` first and pass the resolved values into `fotingo review`.

--- a/internal/commands/ai/testdata/skill_cursor.golden
+++ b/internal/commands/ai/testdata/skill_cursor.golden
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires fotingo CLI.
 metadata:
   author: fotingo
-  version: "1.13.1"
+  version: "1.14.0"
   generatedBy: "dev"
 ---
 
@@ -142,6 +142,7 @@ fotingo review stacks rebase --json
 - Use `fotingo start ... -y` to begin work from an existing issue or a newly created issue.
 - Use `fotingo start --worktree-path <parent> ... --json` when you want an isolated checkout under a specific parent; automation should read `branch.name` and `branch.worktreePath` from the JSON result. Worktree directory names use the hardcoded `fotingo-wt-<branch>` format.
 - `fotingo start` auto-stashes only tracked or staged changes. Untracked-only files and directories stay in place.
+- `fotingo start` refreshes only the default branch during branch preflight, skips the fetch when the local tracking ref is already current, and does not use shallow fetches for that refresh.
 - Prefer non-interactive flags (`-y`, `--json`) in automated runs.
 - Use explicit flags rather than prompts in non-interactive environments.
 - For reviewers, assignees, and labels, run `fotingo search ... --json` first and pass the resolved values into `fotingo review`.

--- a/internal/git/README.md
+++ b/internal/git/README.md
@@ -113,7 +113,7 @@ type Git interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1670>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1733>)
 
 ```go
 func New(cfg *viper.Viper, messages *chan string) (Git, error)
@@ -122,7 +122,7 @@ func New(cfg *viper.Viper, messages *chan string) (Git, error)
 New returns a new instance of a Git client in the current working directory. It supports linked worktrees and keeps credential helper lookups rooted at the active worktree, including repositories that enable extensions.worktreeConfig.
 
 <a name="NewWithCredentialProvider"></a>
-### func [NewWithCredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1702>)
+### func [NewWithCredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1765>)
 
 ```go
 func NewWithCredentialProvider(cfg *viper.Viper, messages *chan string, cp CredentialProvider) (Git, error)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -572,72 +572,64 @@ func (g *git) GetDefaultBranch() (string, error) {
 		return "", fmt.Errorf("git remote is not configured")
 	}
 
-	branch, showErr := g.getRemoteDefaultBranchFromGitCommand(remote)
-	if showErr == nil {
+	if branch, ok := g.getCachedRemoteDefaultBranch(remote); ok {
 		return branch, nil
 	}
 
-	// Prefer cached remote HEAD when available to avoid unnecessary network calls.
-	cachedHeadRefName := plumbing.ReferenceName(fmt.Sprintf("refs/remotes/%s/HEAD", remote))
-	if headRef, err := g.repo.Reference(cachedHeadRefName, false); err == nil {
-		if headRef.Type() == plumbing.SymbolicReference {
-			target := normalizeDefaultBranchName(remote, headRef.Target().Short())
-			if target != "" {
-				return target, nil
-			}
-		}
-	}
-
-	remoteRef, remoteURL, err := g.getConfiguredRemote(remote)
+	branch, err := g.getRemoteDefaultBranchFromSymref(remote)
 	if err != nil {
 		return "", err
 	}
 
-	credentials, err := g.credentialProvider.GetCredentials(remoteURL)
-	if err != nil {
-		return "", fmt.Errorf(
-			"failed to get credentials for remote %s while resolving default branch: %w",
-			remote,
-			err,
-		)
+	if cacheErr := g.cacheRemoteDefaultBranch(remote, branch); cacheErr != nil {
+		(*g.messages) <- fmt.Sprintf("Failed to cache remote HEAD for %s: %s", remote, cacheErr)
 	}
 
-	refs, err := remoteRef.List(&gogit.ListOptions{
-		Auth: credentials,
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to list remote refs for %s: %w", remote, err)
-	}
-
-	// Look for remote HEAD reference that points to the default branch.
-	for _, ref := range refs {
-		if ref.Name() != plumbing.HEAD {
-			continue
-		}
-		target := normalizeDefaultBranchName(remote, ref.Target().Short())
-		if target != "" && target != "HEAD" {
-			return target, nil
-		}
-	}
-
-	return "", fmt.Errorf("could not determine default branch for remote %s: %w", remote, showErr)
+	return branch, nil
 }
 
-func (g *git) getRemoteDefaultBranchFromGitCommand(remote string) (string, error) {
+func (g *git) getCachedRemoteDefaultBranch(remote string) (string, bool) {
+	cachedHeadRefName := plumbing.ReferenceName(fmt.Sprintf("refs/remotes/%s/HEAD", remote))
+	headRef, err := g.repo.Reference(cachedHeadRefName, false)
+	if err != nil || headRef.Type() != plumbing.SymbolicReference {
+		return "", false
+	}
+
+	target := normalizeDefaultBranchName(remote, headRef.Target().Short())
+	if target == "" || target == "HEAD" {
+		return "", false
+	}
+
+	return target, true
+}
+
+func (g *git) cacheRemoteDefaultBranch(remote, branch string) error {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return fmt.Errorf("default branch is required")
+	}
+
+	return g.repo.Storer.SetReference(plumbing.NewSymbolicReference(
+		plumbing.ReferenceName(fmt.Sprintf("refs/remotes/%s/HEAD", remote)),
+		plumbing.NewRemoteReferenceName(remote, branch),
+	))
+}
+
+func (g *git) getRemoteDefaultBranchFromSymref(remote string) (string, error) {
 	worktreeRoot, err := g.worktreeRoot()
 	if err != nil {
 		return "", err
 	}
 
-	stdout, stderr, err := execGitCommand(worktreeRoot, gitNonInteractiveEnv(), "remote", "show", remote)
+	stdout, stderr, err := execGitCommand(worktreeRoot, gitNonInteractiveEnv(), "ls-remote", "--symref", remote, "HEAD")
 	if err != nil {
 		if stderr == "" {
-			return "", fmt.Errorf("failed to inspect remote %s: %w", remote, err)
+			return "", fmt.Errorf("failed to inspect remote %s HEAD: %w", remote, err)
 		}
-		return "", fmt.Errorf("failed to inspect remote %s: %s", remote, stderr)
+		return "", fmt.Errorf("failed to inspect remote %s HEAD: %s", remote, stderr)
 	}
 
-	branch, err := parseRemoteHeadBranch(stdout)
+	branch, err := parseRemoteHeadBranchSymref(stdout)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse remote %s HEAD branch: %w", remote, err)
 	}
@@ -645,15 +637,20 @@ func (g *git) getRemoteDefaultBranchFromGitCommand(remote string) (string, error
 	return branch, nil
 }
 
-func parseRemoteHeadBranch(output string) (string, error) {
+func parseRemoteHeadBranchSymref(output string) (string, error) {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, "HEAD branch:") {
+		if !strings.HasPrefix(line, "ref: ") {
 			continue
 		}
-		branch := strings.TrimSpace(strings.TrimPrefix(line, "HEAD branch:"))
-		branch = strings.TrimPrefix(branch, "refs/heads/")
+
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[2] != "HEAD" {
+			return "", fmt.Errorf("remote HEAD branch is unavailable")
+		}
+
+		branch := strings.TrimSpace(strings.TrimPrefix(fields[1], "refs/heads/"))
 		if branch == "" || branch == "(unknown)" {
 			return "", fmt.Errorf("remote HEAD branch is unavailable")
 		}
@@ -664,7 +661,7 @@ func parseRemoteHeadBranch(output string) (string, error) {
 		return "", fmt.Errorf("failed to read remote output: %w", err)
 	}
 
-	return "", fmt.Errorf("HEAD branch line not found")
+	return "", fmt.Errorf("HEAD symref line not found")
 }
 
 func gitNonInteractiveEnv() []string {
@@ -907,44 +904,25 @@ func (g *git) FetchDefaultBranch() error {
 		return fmt.Errorf("failed to get default branch: %w", err)
 	}
 
-	worktreeRoot, err := g.worktreeRoot()
-	if err != nil {
-		return err
-	}
-
 	remote := strings.TrimSpace(g.GetConfigString("remote"))
 	if remote == "" {
 		return fmt.Errorf("git remote is not configured")
 	}
 
-	(*g.messages) <- fmt.Sprintf("Fetching from remote %s", remote)
-	refspec := fmt.Sprintf(
-		"refs/heads/%s:refs/remotes/%s/%s",
-		defaultBranch,
-		remote,
-		defaultBranch,
-	)
-	_, stderr, err := execGitCommand(
-		worktreeRoot,
-		gitNonInteractiveEnv(),
-		"fetch",
-		"--depth=1",
-		remote,
-		refspec,
-	)
+	localHash, hasLocalRef, err := g.getLocalRemoteBranchHash(remote, defaultBranch)
 	if err != nil {
-		if stderr != "" {
-			return fmt.Errorf("failed to fetch from remote: %s", stderr)
+		return fmt.Errorf("failed to inspect default branch reference: %w", err)
+	}
+
+	if hasLocalRef {
+		remoteHash, err := g.getRemoteBranchTipHash(remote, defaultBranch)
+		if err == nil && remoteHash == localHash {
+			(*g.messages) <- fmt.Sprintf("Default branch %s is already current", defaultBranch)
+			return nil
 		}
-		return fmt.Errorf("failed to fetch from remote: %w", err)
 	}
 
-	remoteDefaultRef := plumbing.NewRemoteReferenceName(remote, defaultBranch)
-	if _, err := g.repo.Reference(remoteDefaultRef, true); err != nil {
-		return fmt.Errorf("failed to get default branch reference: %w", err)
-	}
-
-	return nil
+	return g.fetchDefaultBranchRef(remote, defaultBranch)
 }
 
 func (g *git) prepareIssueBranch(issue *jira.Issue) (string, string, string, error) {
@@ -986,10 +964,9 @@ func (g *git) resolveDefaultBranchReference(remote, defaultBranch string) (*plum
 		return branchRef, nil
 	}
 
-	(*g.messages) <- fmt.Sprintf("Fetching from remote %s", remote)
-	if err := g.fetch(remote); err != nil {
-		(*g.messages) <- fmt.Sprintf("Failed to fetch from remote: %s", err)
-		return nil, fmt.Errorf("failed to fetch from remote: %w", err)
+	if err := g.fetchDefaultBranchRef(remote, defaultBranch); err != nil {
+		(*g.messages) <- fmt.Sprintf("Failed to refresh default branch %s from remote %s: %s", defaultBranch, remote, err)
+		return nil, fmt.Errorf("failed to refresh default branch reference: %w", err)
 	}
 
 	branchRef, err = g.repo.Reference(remoteDefaultRef, true)
@@ -999,6 +976,92 @@ func (g *git) resolveDefaultBranchReference(remote, defaultBranch string) (*plum
 	}
 
 	return branchRef, nil
+}
+
+func (g *git) getLocalRemoteBranchHash(remote, branch string) (plumbing.Hash, bool, error) {
+	ref, err := g.repo.Reference(plumbing.NewRemoteReferenceName(remote, branch), true)
+	if err == nil {
+		return ref.Hash(), true, nil
+	}
+	if errors.Is(err, plumbing.ErrReferenceNotFound) || strings.Contains(err.Error(), "reference not found") {
+		return plumbing.ZeroHash, false, nil
+	}
+	return plumbing.ZeroHash, false, err
+}
+
+func (g *git) getRemoteBranchTipHash(remote, branch string) (plumbing.Hash, error) {
+	worktreeRoot, err := g.worktreeRoot()
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	refName := fmt.Sprintf("refs/heads/%s", branch)
+	stdout, stderr, err := execGitCommand(worktreeRoot, gitNonInteractiveEnv(), "ls-remote", "--refs", remote, refName)
+	if err != nil {
+		if stderr == "" {
+			return plumbing.ZeroHash, fmt.Errorf("failed to inspect remote branch %s on %s: %w", branch, remote, err)
+		}
+		return plumbing.ZeroHash, fmt.Errorf("failed to inspect remote branch %s on %s: %s", branch, remote, stderr)
+	}
+
+	hash, err := parseRemoteRefHash(stdout, refName)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	return hash, nil
+}
+
+func parseRemoteRefHash(output string, refName string) (plumbing.Hash, error) {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 || fields[1] != refName {
+			continue
+		}
+		return plumbing.NewHash(fields[0]), nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to read remote ref output: %w", err)
+	}
+
+	return plumbing.ZeroHash, fmt.Errorf("remote ref %s not found", refName)
+}
+
+func (g *git) fetchDefaultBranchRef(remote, defaultBranch string) error {
+	worktreeRoot, err := g.worktreeRoot()
+	if err != nil {
+		return err
+	}
+
+	(*g.messages) <- fmt.Sprintf("Fetching branch %s from remote %s", defaultBranch, remote)
+	refspec := fmt.Sprintf(
+		"refs/heads/%s:refs/remotes/%s/%s",
+		defaultBranch,
+		remote,
+		defaultBranch,
+	)
+	_, stderr, err := execGitCommand(
+		worktreeRoot,
+		gitNonInteractiveEnv(),
+		"fetch",
+		"--no-tags",
+		remote,
+		refspec,
+	)
+	if err != nil {
+		if stderr != "" {
+			return fmt.Errorf("failed to fetch from remote: %s", stderr)
+		}
+		return fmt.Errorf("failed to fetch from remote: %w", err)
+	}
+
+	if _, err := g.repo.Reference(plumbing.NewRemoteReferenceName(remote, defaultBranch), true); err != nil {
+		return fmt.Errorf("failed to get default branch reference: %w", err)
+	}
+
+	return nil
 }
 
 func issueWorktreePath(worktreeRoot, branchName string, options WorktreeOptions) (string, error) {

--- a/internal/git/git_fs_test.go
+++ b/internal/git/git_fs_test.go
@@ -444,7 +444,7 @@ func (s *GitFsTestSuite) TestGetDefaultBranch_InvalidRemote() {
 	s.gitClient.Config.Set("git.remote", "nonexistent")
 	_, err := s.gitClient.GetDefaultBranch()
 	assert.Error(s.T(), err)
-	assert.Contains(s.T(), err.Error(), "failed to get remote")
+	assert.Contains(s.T(), err.Error(), "failed to inspect remote nonexistent HEAD")
 }
 
 // --- fetch error path tests ---
@@ -745,7 +745,94 @@ echo password=test-pass
 	assert.Equal(t, "test-pass", credentials.Password)
 }
 
-func TestFetchDefaultBranch_UsesGitRemoteFallbackWhenRepoRemoteIsMissing(t *testing.T) {
+func TestFetchDefaultBranch_UsesTargetedNonShallowFetchWhenRemoteRefIsMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	bareDir := filepath.Join(tmpDir, "remote.git")
+	sourceDir := filepath.Join(tmpDir, "source")
+	targetDir := filepath.Join(tmpDir, "target")
+
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+
+	runGitCommand(t, "", "init", "--bare", bareDir)
+
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+	runGitCommand(t, "", "init", sourceDir)
+	runGitCommand(t, sourceDir, "config", "user.name", "Test User")
+	runGitCommand(t, sourceDir, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "README.md"), []byte("source\n"), 0644))
+	runGitCommand(t, sourceDir, "add", "README.md")
+	runGitCommand(t, sourceDir, "commit", "--no-verify", "-m", "feat: seed remote")
+	runGitCommand(t, sourceDir, "branch", "-M", "main")
+	runGitCommand(t, sourceDir, "remote", "add", "origin", "file://"+bareDir)
+	runGitCommand(t, sourceDir, "push", "-u", "origin", "main")
+	runGitCommand(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+	runGitCommand(t, "", "init", targetDir)
+	runGitCommand(t, targetDir, "config", "user.name", "Test User")
+	runGitCommand(t, targetDir, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "LOCAL.md"), []byte("target\n"), 0644))
+	runGitCommand(t, targetDir, "add", "LOCAL.md")
+	runGitCommand(t, targetDir, "commit", "--no-verify", "-m", "feat: local repo")
+	runGitCommand(t, targetDir, "branch", "-M", "main")
+	runGitCommand(t, targetDir, "remote", "add", "origin", "file://"+bareDir)
+
+	originalExecGitCommand := execGitCommand
+	var capturedFetchArgs []string
+	defer func() {
+		execGitCommand = originalExecGitCommand
+	}()
+
+	execGitCommand = func(dir string, env []string, args ...string) (string, string, error) {
+		require.Equal(t, targetDir, dir)
+		require.Contains(t, strings.Join(env, "\n"), "GIT_TERMINAL_PROMPT=0")
+
+		switch strings.Join(args, " ") {
+		case "ls-remote --symref origin HEAD":
+			return "ref: refs/heads/main\tHEAD\n0123456789012345678901234567890123456789\tHEAD\n", "", nil
+		default:
+			if len(args) > 0 && args[0] == "fetch" {
+				capturedFetchArgs = append([]string{}, args...)
+			}
+			return originalExecGitCommand(dir, env, args...)
+		}
+	}
+
+	t.Chdir(targetDir)
+
+	cfg := config.NewDefaultConfig()
+	messages := make(chan string, 4)
+	client, err := NewWithCredentialProvider(cfg, &messages, &mockCredentialProvider{})
+	require.NoError(t, err)
+
+	internalGit, ok := client.(*git)
+	require.True(t, ok)
+
+	err = internalGit.FetchDefaultBranch()
+	require.NoError(t, err)
+
+	remoteMain := plumbing.NewRemoteReferenceName("origin", "main")
+	_, err = internalGit.repo.Reference(remoteMain, true)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{
+			"fetch",
+			"--no-tags",
+			"origin",
+			"refs/heads/main:refs/remotes/origin/main",
+		},
+		capturedFetchArgs,
+	)
+
+	shallow, stderr, cmdErr := originalExecGitCommand(targetDir, gitNonInteractiveEnv(), "rev-parse", "--is-shallow-repository")
+	require.NoError(t, cmdErr, stderr)
+	assert.Equal(t, "false", shallow)
+}
+
+func TestFetchDefaultBranch_SkipsFetchWhenRemoteTipMatchesLocalTrackingRef(t *testing.T) {
 	tmpDir := t.TempDir()
 	bareDir := filepath.Join(tmpDir, "remote.git")
 	sourceDir := filepath.Join(tmpDir, "source")
@@ -777,28 +864,21 @@ func TestFetchDefaultBranch_UsesGitRemoteFallbackWhenRepoRemoteIsMissing(t *test
 	runGitCommand(t, targetDir, "commit", "--no-verify", "-m", "feat: local repo")
 	runGitCommand(t, targetDir, "branch", "-M", "main")
 	runGitCommand(t, targetDir, "remote", "add", "origin", "file://"+bareDir)
+	runGitCommand(t, targetDir, "fetch", "origin", "refs/heads/main:refs/remotes/origin/main")
 
 	originalExecGitCommand := execGitCommand
-	var capturedFetchArgs []string
+	var recorded [][]string
 	defer func() {
 		execGitCommand = originalExecGitCommand
 	}()
 
 	execGitCommand = func(dir string, env []string, args ...string) (string, string, error) {
 		require.Equal(t, targetDir, dir)
-		require.Contains(t, strings.Join(env, "\n"), "GIT_TERMINAL_PROMPT=0")
-
-		switch strings.Join(args, " ") {
-		case "remote show origin":
-			return "* remote origin\n  HEAD branch: main\n", "", nil
-		case "remote get-url origin":
-			return "file://" + bareDir, "", nil
-		default:
-			if len(args) > 0 && args[0] == "fetch" {
-				capturedFetchArgs = append([]string{}, args...)
-			}
-			return originalExecGitCommand(dir, env, args...)
+		recorded = append(recorded, append([]string{}, args...))
+		if strings.Join(args, " ") == "ls-remote --symref origin HEAD" {
+			return "ref: refs/heads/main\tHEAD\n0123456789012345678901234567890123456789\tHEAD\n", "", nil
 		}
+		return originalExecGitCommand(dir, env, args...)
 	}
 
 	t.Chdir(targetDir)
@@ -814,19 +894,9 @@ func TestFetchDefaultBranch_UsesGitRemoteFallbackWhenRepoRemoteIsMissing(t *test
 	err = internalGit.FetchDefaultBranch()
 	require.NoError(t, err)
 
-	remoteMain := plumbing.NewRemoteReferenceName("origin", "main")
-	_, err = internalGit.repo.Reference(remoteMain, true)
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		[]string{
-			"fetch",
-			"--depth=1",
-			"origin",
-			"refs/heads/main:refs/remotes/origin/main",
-		},
-		capturedFetchArgs,
-	)
+	for _, args := range recorded {
+		assert.NotEqual(t, "fetch", args[0], "expected no fetch when remote tip matches local tracking ref")
+	}
 }
 
 func runGitCommand(t *testing.T, dir string, args ...string) {
@@ -1057,10 +1127,8 @@ func (s *GitCredentialTestSuite) TestGetDefaultBranch_Success() {
 	assert.Equal(s.T(), "master", branch)
 }
 
-func (s *GitCredentialTestSuite) TestGetDefaultBranch_CredentialError() {
-	s.gitClient.credentialProvider = &failingCredentialProvider{}
-
-	// Remove cached remote refs to force GetDefaultBranch through the credentialed remote-list path.
+func (s *GitCredentialTestSuite) TestGetDefaultBranch_RemoteLookupError() {
+	// Remove cached remote refs to force GetDefaultBranch through the remote HEAD lookup path.
 	_ = s.workRepo.Storer.RemoveReference(plumbing.ReferenceName("refs/remotes/origin/HEAD"))
 	_ = s.workRepo.Storer.RemoveReference(plumbing.ReferenceName("refs/remotes/origin/main"))
 	_ = s.workRepo.Storer.RemoveReference(plumbing.ReferenceName("refs/remotes/origin/master"))
@@ -1074,7 +1142,7 @@ func (s *GitCredentialTestSuite) TestGetDefaultBranch_CredentialError() {
 
 	_, err := s.gitClient.GetDefaultBranch()
 	assert.Error(s.T(), err)
-	assert.Contains(s.T(), err.Error(), "failed to get credentials")
+	assert.Contains(s.T(), err.Error(), "failed to inspect remote origin HEAD")
 }
 
 // --- DoesBranchExistInRemote tests ---

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -951,6 +951,35 @@ func (suite *GitTestSuite) TestLooksLikeCredentialPrompt() {
 	assert.False(suite.T(), looksLikeCredentialPrompt(""))
 }
 
+func (suite *GitTestSuite) TestGetDefaultBranch_PrefersCachedRemoteHead() {
+	original := execGitCommand
+	suite.T().Cleanup(func() { execGitCommand = original })
+
+	execGitCommand = func(string, []string, ...string) (string, string, error) {
+		suite.T().Fatal("expected cached remote HEAD to avoid shelling out")
+		return "", "", nil
+	}
+
+	branch, err := suite.git.GetDefaultBranch()
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "main", branch)
+}
+
+func (suite *GitTestSuite) TestParseRemoteHeadBranchSymref() {
+	branch, err := parseRemoteHeadBranchSymref("ref: refs/heads/main\tHEAD\nabc123\tHEAD\n")
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "main", branch)
+}
+
+func (suite *GitTestSuite) TestParseRemoteRefHash() {
+	hash, err := parseRemoteRefHash("0123456789012345678901234567890123456789\trefs/heads/main\n", "refs/heads/main")
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), plumbing.NewHash("0123456789012345678901234567890123456789"), hash)
+}
+
 func (suite *GitTestSuite) TestHasUncommittedChanges_WithNewFile() {
 	// Create a new untracked file
 	worktree, err := suite.repo.Worktree()


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Make start branch refresh safe and conditional
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: \Fetching your open issues...
Found 17 open issues
🎉 Done in 548ms should feel faster without using shallow fetches that can surprise local repositories.

What changed:
- resolve the default branch from cached remote metadata first
- probe the remote tip and skip fetch when the local tracking ref is already current
- use a targeted non-shallow default-branch fetch only when refresh is actually needed
- remove the broad-fetch fallback from branch preparation
- add regression coverage for cached HEAD resolution, conditional fetch skipping, and non-shallow targeted refresh
- update start docs and generated AI workflow guidance
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
Fixes [FOTINGO-43](https://tagoro9.atlassian.net/browse/FOTINGO-43)
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix(start): avoid shallow default branch refresh (+250/-90)
* docs(start): describe safer branch refresh (+9/-4)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)