### PR TITLE
[FOTINGO-49] fotingo inspect doesn't work outisde of a git repo

### DIFF
--- a/internal/commands/inspect/workflow.go
+++ b/internal/commands/inspect/workflow.go
@@ -87,12 +87,6 @@ type WorkflowRunner struct {
 func (r WorkflowRunner) Run() (WorkflowResult, error) {
 	output := WorkflowResult{}
 
-	statusCh := make(chan string, 10)
-	gitClient, err := r.Deps.NewGitClient(r.Config, &statusCh)
-	if err != nil {
-		return WorkflowResult{}, err
-	}
-
 	if r.Options.Issue != "" {
 		jiraClient, err := r.Deps.NewJiraClient(r.Config)
 		if err != nil {
@@ -115,6 +109,12 @@ func (r WorkflowRunner) Run() (WorkflowResult, error) {
 			URL:         jiraClient.GetIssueURL(issue.Key),
 		}
 		return output, nil
+	}
+
+	statusCh := make(chan string, 10)
+	gitClient, err := r.Deps.NewGitClient(r.Config, &statusCh)
+	if err != nil {
+		return WorkflowResult{}, err
 	}
 
 	branchName := r.Options.Branch

--- a/internal/commands/inspect/workflow_test.go
+++ b/internal/commands/inspect/workflow_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tagoro9/fotingo/internal/auth"
 	"github.com/tagoro9/fotingo/internal/git"
 	"github.com/tagoro9/fotingo/internal/github"
 	"github.com/tagoro9/fotingo/internal/jira"
+	"github.com/tagoro9/fotingo/internal/tracker"
 )
 
 type inspectGitStub struct {
@@ -124,6 +126,52 @@ func (s *inspectGitHubStub) GetPullRequestDiscussion(prNumber int) (*github.Pull
 	}
 	return s.discussion, nil
 }
+
+type inspectJiraStub struct {
+	issue *jira.Issue
+}
+
+func (s inspectJiraStub) Authenticate() (*auth.AccessToken, error) { return &auth.AccessToken{}, nil }
+func (s inspectJiraStub) GetConfig() *viper.Viper                  { return viper.New() }
+func (s inspectJiraStub) SaveConfig(string, any) error             { return nil }
+func (s inspectJiraStub) Name() string                             { return "Jira" }
+func (s inspectJiraStub) GetCurrentUser() (*tracker.User, error)   { return nil, nil }
+func (s inspectJiraStub) GetUserOpenIssues() ([]tracker.Issue, error) {
+	return nil, nil
+}
+func (s inspectJiraStub) GetIssue(string) (*tracker.Issue, error) { return nil, nil }
+func (s inspectJiraStub) AssignIssue(string, string) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s inspectJiraStub) CreateIssue(tracker.CreateIssueInput) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s inspectJiraStub) GetProjectIssueTypes(string) ([]tracker.ProjectIssueType, error) {
+	return nil, nil
+}
+func (s inspectJiraStub) SetIssueStatus(string, tracker.IssueStatus) (*tracker.Issue, error) {
+	return nil, nil
+}
+func (s inspectJiraStub) AddComment(string, string) error { return nil }
+func (s inspectJiraStub) CreateRelease(tracker.CreateReleaseInput) (*tracker.Release, error) {
+	return nil, nil
+}
+func (s inspectJiraStub) SetFixVersion([]string, *tracker.Release) error { return nil }
+func (s inspectJiraStub) IsValidIssueID(string) bool                     { return true }
+func (s inspectJiraStub) GetIssueURL(issueID string) string {
+	return "https://jira.example.com/browse/" + issueID
+}
+func (s inspectJiraStub) GetIssueUrl(issueID string) (string, error) {
+	return s.GetIssueURL(issueID), nil
+}
+func (s inspectJiraStub) GetJiraIssue(string) (*jira.Issue, error) { return s.issue, nil }
+func (s inspectJiraStub) SetJiraIssueStatus(string, jira.IssueStatus) (*jira.Issue, error) {
+	return nil, nil
+}
+func (s inspectJiraStub) SearchIssues(string, string, []tracker.IssueType, int) ([]tracker.Issue, error) {
+	return nil, nil
+}
+
 func TestWorkflowRunnerRun_UsesDefaultBranchDivergenceCommits(t *testing.T) {
 	gitStub := &inspectGitStub{
 		currentBranch: "feature/TEST-123",
@@ -157,6 +205,38 @@ func TestWorkflowRunnerRun_UsesDefaultBranchDivergenceCommits(t *testing.T) {
 	assert.Equal(t, 0, gitStub.commitsSinceCalls)
 }
 
+func TestWorkflowRunnerRun_WithIssueSkipsGitInitialization(t *testing.T) {
+	jiraClient := inspectJiraStub{
+		issue: &jira.Issue{
+			Key:     "TEST-123",
+			Summary: "Fix login bug",
+			Status:  "To Do",
+			Type:    "Bug",
+		},
+	}
+
+	runner := WorkflowRunner{
+		Config:  viper.New(),
+		Options: WorkflowOptions{Issue: "TEST-123"},
+		Deps: WorkflowDeps{
+			NewGitClient: func(*viper.Viper, *chan string) (git.Git, error) {
+				return nil, fmt.Errorf("git should not be initialized")
+			},
+			NewJiraClient: func(*viper.Viper) (jira.Jira, error) {
+				return jiraClient, nil
+			},
+		},
+	}
+
+	result, err := runner.Run()
+	require.NoError(t, err)
+	require.NotNil(t, result.Issue)
+	assert.Equal(t, "TEST-123", result.Issue.Key)
+	assert.Equal(t, "Fix login bug", result.Issue.Summary)
+	assert.Equal(t, "https://jira.example.com/browse/TEST-123", result.Issue.URL)
+	assert.Nil(t, result.Branch)
+}
+
 func TestWorkflowRunnerRun_DefaultBranchSkipsCommitCollection(t *testing.T) {
 	gitStub := &inspectGitStub{
 		currentBranch: "main",
@@ -186,6 +266,7 @@ func TestWorkflowRunnerRun_DefaultBranchSkipsCommitCollection(t *testing.T) {
 	assert.Equal(t, 0, gitStub.commitsSinceDefaultCalls)
 	assert.Equal(t, 0, gitStub.commitsSinceCalls)
 }
+
 func TestWorkflowRunnerRun_IncludesPullRequestWhenBranchHasOne(t *testing.T) {
 	gitStub := &inspectGitStub{
 		currentBranch: "feature/FOTINGO-30",

--- a/pkg/commands/execution_test.go
+++ b/pkg/commands/execution_test.go
@@ -306,6 +306,33 @@ func (s *ExecutionTestSuite) TestInspect_WithIssueFlag() {
 	assert.Nil(t, result.PullRequest)
 }
 
+func (s *ExecutionTestSuite) TestInspect_WithIssueFlagOutsideGitRepo() {
+	t := s.T()
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(s.tempDir))
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+	})
+
+	output := captureStdout(t, func() {
+		Fotingo.SetArgs([]string{"inspect", "--issue", "TEST-123"})
+		err := Fotingo.Execute()
+		assert.NoError(t, err)
+	})
+
+	var result InspectOutput
+	err = json.Unmarshal([]byte(extractJSON(output)), &result)
+	require.NoError(t, err, "output should contain valid JSON, got: %s", output)
+
+	require.NotNil(t, result.Issue, "issue should be present in output")
+	assert.Equal(t, "TEST-123", result.Issue.Key)
+	assert.Equal(t, "Fix login bug", result.Issue.Summary)
+	assert.Nil(t, result.Branch)
+	assert.Nil(t, result.PullRequest)
+}
+
 func (s *ExecutionTestSuite) TestInspect_DefaultBranchInfo() {
 	t := s.T()
 


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Allow inspect issue lookup outside Git repositories
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: fotingo inspect --issue PROJ-123 failed outside a Git repository because the inspect workflow initialized Git before resolving an explicit issue lookup. This broke a valid issue-inspection path when the caller was not in repo context.

What changed:
- short-circuit inspect --issue before Git client initialization
- add a workflow regression asserting Git is not initialized for explicit issue inspection
- add a command-level regression covering execution from a non-repo directory

Testing:
- go test ./internal/commands/inspect
- go test ./pkg/commands
- pre-commit run -a

Risk:
- low; branch-based inspect behavior is unchanged and the issue-only path now avoids an unnecessary Git dependency
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
Fixes [FOTINGO-49](https://tagoro9.atlassian.net/browse/FOTINGO-49)
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix: allow inspect issue lookup outside git repos (+114/-6)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)