### PR TITLE
[FOTINGO-50] Fotingo is created branches with invalid characters

### DIFF
--- a/internal/git/README.md
+++ b/internal/git/README.md
@@ -113,7 +113,7 @@ type Git interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1733>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1758>)
 
 ```go
 func New(cfg *viper.Viper, messages *chan string) (Git, error)
@@ -122,7 +122,7 @@ func New(cfg *viper.Viper, messages *chan string) (Git, error)
 New returns a new instance of a Git client in the current working directory. It supports linked worktrees and keeps credential helper lookups rooted at the active worktree, including repositories that enable extensions.worktreeConfig.
 
 <a name="NewWithCredentialProvider"></a>
-### func [NewWithCredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1765>)
+### func [NewWithCredentialProvider](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L1790>)
 
 ```go
 func NewWithCredentialProvider(cfg *viper.Viper, messages *chan string, cp CredentialProvider) (Git, error)
@@ -142,7 +142,7 @@ type RemoteConfigurable interface {
 ```
 
 <a name="TemplateIssue"></a>
-## type [TemplateIssue](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L199-L204>)
+## type [TemplateIssue](<https://github.com/tagoro9/fotingo/blob/main/internal/git/git.go#L202-L207>)
 
 TODO Is this needed now that we have the issue struct?
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -192,6 +192,9 @@ var placeholderPatterns = map[string]struct {
 }
 
 var fallbackIssueIDPattern = regexp.MustCompile(`(?i)(^|[^a-z0-9])([a-z][a-z0-9_]+-\d+)($|[^a-z0-9])`)
+var branchNameUnsafePattern = regexp.MustCompile(`[^a-z0-9._/-]+`)
+var branchNameUnderscorePattern = regexp.MustCompile(`_+`)
+var branchNameSlashPattern = regexp.MustCompile(`/+`)
 var worktreeDirUnsafePattern = regexp.MustCompile(`[^a-z0-9._-]+`)
 var worktreeDirDashPattern = regexp.MustCompile(`-+`)
 
@@ -1094,6 +1097,25 @@ func directoryFriendlyBranchName(branchName string) string {
 	return strings.Trim(normalized, "-.")
 }
 
+func sanitizeBranchName(branchName string) string {
+	normalized := strings.ToLower(strings.TrimSpace(branchName))
+	normalized = branchNameUnsafePattern.ReplaceAllString(normalized, "_")
+	normalized = branchNameUnderscorePattern.ReplaceAllString(normalized, "_")
+	normalized = branchNameSlashPattern.ReplaceAllString(normalized, "/")
+
+	parts := strings.Split(normalized, "/")
+	cleanParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.Trim(part, "._-")
+		if part == "" {
+			continue
+		}
+		cleanParts = append(cleanParts, part)
+	}
+
+	return strings.Join(cleanParts, "/")
+}
+
 func (g *git) buildBranchName(issue *jira.Issue) (string, error) {
 	branchTemplate := g.GetConfigString("branchTemplate")
 	if branchTemplate == "" {
@@ -1113,7 +1135,10 @@ func (g *git) buildBranchName(issue *jira.Issue) (string, error) {
 		return "", fmt.Errorf("failed to execute branch template: %w", err)
 	}
 
-	branchName := strings.ToLower(data.String())
+	branchName := sanitizeBranchName(data.String())
+	if branchName == "" {
+		return "", fmt.Errorf("failed to build branch name from template")
+	}
 
 	// Trim branch name to 244 characters to avoid git reference name issues
 	if len(branchName) > 244 {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -253,6 +253,19 @@ func (suite *GitTestSuite) TestDirectoryFriendlyBranchName() {
 	assert.Equal(suite.T(), "f-test-123_fix-review-base", directoryFriendlyBranchName("f/TEST-123_fix review base"))
 }
 
+func (suite *GitTestSuite) TestSanitizeBranchName() {
+	assert.Equal(
+		suite.T(),
+		"c/ticket-123_do-something-with-unicode",
+		sanitizeBranchName("c/TICKET-123—_do-something-with-unicode"),
+	)
+	assert.Equal(
+		suite.T(),
+		"f/test-123_fix_review_base",
+		sanitizeBranchName("///F//TEST-123__Fix Review Base!!!"),
+	)
+}
+
 func (suite *GitTestSuite) TestGetIssueId_DetachedHead() {
 	// Get the current HEAD commit
 	head, err := suite.repo.Head()
@@ -347,6 +360,26 @@ func (suite *GitTestSuite) TestCreateIssueBranch() {
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "f/test-123_test-branch", branchName)
+
+	_, err = suite.repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *GitTestSuite) TestCreateIssueBranch_SanitizesUnicodePunctuation() {
+	issue := &jira.Issue{
+		Key:     "TICKET-1234",
+		Type:    "Task",
+		Summary: "Implement this — feature",
+	}
+
+	branchName, err := suite.git.CreateIssueBranch(issue)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(
+		suite.T(),
+		"c/ticket-1234_implement_this_feature",
+		branchName,
+	)
 
 	_, err = suite.repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
 	assert.NoError(suite.T(), err)


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Sanitize generated issue branch names
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: branch names generated from Jira summaries could include Unicode punctuation such as an em dash.

What changed:
- sanitize rendered branch templates before creating git refs
- add regression coverage for Unicode punctuation in branch summaries
- refresh generated git docs

Testing:
- mise exec go@1.25.7 -- go test ./internal/git ./...
- mise exec go@1.25.7 -- pre-commit run -a
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
Fixes [FOTINGO-50](https://tagoro9.atlassian.net/browse/FOTINGO-50)
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix: sanitize generated branch names (+62/-4)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)