### PR TITLE
[FOTINGO-51] Support using atlassian cloud service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Prerequisites:
    - A classic GitHub PAT from `https://github.com/settings/tokens` with `repo` scope
 2. Jira authentication:
    - Atlassian API token from `https://id.atlassian.com/manage-profile/security/api-tokens`, or
+   - Atlassian Cloud service-account scoped token with Jira root `https://api.atlassian.com/ex/jira/{cloudId}`, or
    - OAuth only in internal binaries compiled with Jira OAuth client credentials
 3. Jira account email
-4. Jira server URL (for example `https://yourcompany.atlassian.net`)
+4. Jira server URL (for example `https://yourcompany.atlassian.net`) or Atlassian Cloud API root
 
 Jira OAuth client credentials include a client secret and are intended for internal builds only.
 Committing or broadly distributing binaries with embedded Jira OAuth client secret is not considered safe.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,15 +2,16 @@
 
 ## Environment Variables
 
-| Variable                  | Description                                                       |
-| ------------------------- | ----------------------------------------------------------------- |
-| `FOTINGO_JIRA_ROOT`       | Jira server URL (for example `https://yourcompany.atlassian.net`) |
-| `FOTINGO_JIRA_USER_LOGIN` | Jira username (email)                                             |
-| `FOTINGO_JIRA_USER_TOKEN` | Jira API token                                                    |
-| `FOTINGO_GIT_REMOTE`      | Git remote name (default: `origin`)                               |
-| `GITHUB_TOKEN`            | GitHub classic PAT with `repo` scope                              |
+| Variable                  | Description                               |
+| ------------------------- | ----------------------------------------- |
+| `FOTINGO_JIRA_ROOT`       | Jira site URL or Atlassian Cloud API root |
+| `FOTINGO_JIRA_USER_LOGIN` | Jira username (email)                     |
+| `FOTINGO_JIRA_USER_TOKEN` | Jira API token                            |
+| `FOTINGO_GIT_REMOTE`      | Git remote name (default: `origin`)       |
+| `GITHUB_TOKEN`            | GitHub classic PAT with `repo` scope      |
 
 If `jira.root` / `FOTINGO_JIRA_ROOT` is not set, interactive Jira-backed commands prompt for it and persist it.
+For Atlassian Cloud service accounts, set it to `https://api.atlassian.com/ex/jira/{cloudId}`.
 
 ## Configuration File
 
@@ -50,9 +51,9 @@ jira:
 | `github.cache.orgMembersTTL`    | Organization members cache TTL                 |
 | `github.cache.teamsTTL`         | Organization teams cache TTL                   |
 | `github.cache.userProfilesTTL`  | GitHub user profile cache TTL                  |
-| `jira.root`                     | Jira server URL                                |
-| `jira.user.login`               | Jira username                                  |
-| `jira.user.token`               | Jira API token                                 |
+| `jira.root`                     | Jira site URL or Atlassian Cloud API root      |
+| `jira.user.login`               | Jira username; not used with service accounts  |
+| `jira.user.token`               | Jira API token or scoped service-account token |
 | `jira.cache.issueTypesTTL`      | Jira issue types cache TTL                     |
 | `cache.path`                    | Override cache DB path                         |
 | `telemetry.enabled`             | Enable anonymous telemetry (`true` by default) |
@@ -77,6 +78,7 @@ Token setup references:
 
 - GitHub token auth: create a classic PAT at `https://github.com/settings/tokens` with `repo` scope.
 - Jira token auth: create an Atlassian API token at `https://id.atlassian.com/manage-profile/security/api-tokens`.
+- Jira service-account auth: use the Atlassian Cloud API root `https://api.atlassian.com/ex/jira/{cloudId}` and a scoped token; no username is required.
 
 ## Templates
 

--- a/internal/commands/start/link_resolver.go
+++ b/internal/commands/start/link_resolver.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/tagoro9/fotingo/internal/commandruntime"
+	"github.com/tagoro9/fotingo/internal/jira"
 	"github.com/tagoro9/fotingo/internal/tracker"
 )
 
@@ -126,7 +126,7 @@ func NormalizeIssueInput(raw string, jiraRoot string) string {
 }
 
 func extractIssueIDFromJiraBrowseURL(raw string, jiraRoot string) (string, bool) {
-	normalizedRoot, err := commandruntime.NormalizeHTTPSRootURL(jiraRoot, "jira root")
+	normalizedRoot, err := jira.NormalizeRootURL(jiraRoot, false)
 	if err != nil {
 		return "", false
 	}

--- a/internal/jira/README.md
+++ b/internal/jira/README.md
@@ -13,6 +13,7 @@ import "github.com/tagoro9/fotingo/internal/jira"
 
 - [Variables](<#variables>)
 - [func IsUnauthorizedError\(err error\) bool](<#IsUnauthorizedError>)
+- [func NormalizeRootURL\(raw string, allowHTTP bool\) \(string, error\)](<#NormalizeRootURL>)
 - [func ShouldWarnIgnoredStoredOAuthToken\(cfg \*viper.Viper\) bool](<#ShouldWarnIgnoredStoredOAuthToken>)
 - [type Issue](<#Issue>)
   - [func \(i \*Issue\) Info\(\) string](<#Issue.Info>)
@@ -45,6 +46,15 @@ func IsUnauthorizedError(err error) bool
 ```
 
 IsUnauthorizedError returns true when the Jira API error corresponds to HTTP 401.
+
+<a name="NormalizeRootURL"></a>
+## func [NormalizeRootURL](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1536>)
+
+```go
+func NormalizeRootURL(raw string, allowHTTP bool) (string, error)
+```
+
+NormalizeRootURL validates and normalizes a Jira site root URL or Atlassian Cloud Jira API root URL.
 
 <a name="ShouldWarnIgnoredStoredOAuthToken"></a>
 ## func [ShouldWarnIgnoredStoredOAuthToken](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L507>)

--- a/internal/jira/README.md
+++ b/internal/jira/README.md
@@ -39,7 +39,7 @@ var (
 ```
 
 <a name="IsUnauthorizedError"></a>
-## func [IsUnauthorizedError](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L515>)
+## func [IsUnauthorizedError](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L572>)
 
 ```go
 func IsUnauthorizedError(err error) bool
@@ -57,7 +57,7 @@ func NormalizeRootURL(raw string, allowHTTP bool) (string, error)
 NormalizeRootURL validates and normalizes a Jira site root URL or Atlassian Cloud Jira API root URL.
 
 <a name="ShouldWarnIgnoredStoredOAuthToken"></a>
-## func [ShouldWarnIgnoredStoredOAuthToken](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L507>)
+## func [ShouldWarnIgnoredStoredOAuthToken](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L564>)
 
 ```go
 func ShouldWarnIgnoredStoredOAuthToken(cfg *viper.Viper) bool
@@ -164,7 +164,7 @@ type Jira interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1289>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1349>)
 
 ```go
 func New(cfg *viper.Viper) (Jira, error)
@@ -173,7 +173,7 @@ func New(cfg *viper.Viper) (Jira, error)
 New returns a new instance of an authenticated Jira client
 
 <a name="NewWithHTTPClient"></a>
-### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1258>)
+### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1318>)
 
 ```go
 func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string) (Jira, error)
@@ -182,7 +182,7 @@ func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string
 NewWithHTTPClient returns a new Jira client using the provided HTTP client and base URL. This bypasses OAuth authentication and is intended for testing with mock servers.
 
 <a name="NewWithOptions"></a>
-### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1294>)
+### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1354>)
 
 ```go
 func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
@@ -191,7 +191,7 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
 NewWithOptions returns an authenticated Jira client with prompt behavior controls.
 
 <a name="TransitionMapping"></a>
-## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L587-L591>)
+## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L647-L651>)
 
 TransitionMapping maps IssueStatus to regex patterns that should match transition names
 

--- a/internal/jira/auth_flow_test.go
+++ b/internal/jira/auth_flow_test.go
@@ -75,6 +75,76 @@ func TestAuthenticate_ReturnsAuthRequiredWhenPromptDisabled(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrAuthRequired))
 }
 
+func TestAuthenticate_RegularJiraRootRequiresUserLoginWithAPIToken(t *testing.T) {
+	cfg := viper.New()
+	cfg.Set("jira.root", "https://acme.atlassian.net")
+	cfg.Set("jira.user.token", "api-token")
+
+	client := &jira{
+		ViperConfigurableService: &config.ViperConfigurableService{Config: cfg, Prefix: "jira"},
+		allowPrompt:              false,
+	}
+
+	_, err := client.Authenticate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAuthRequired)
+}
+
+func TestAuthenticate_UsesBearerTokenForAtlassianCloudAPIURL(t *testing.T) {
+	cfg := viper.New()
+	cfg.Set("jira.root", "https://api.atlassian.com/ex/jira/cloud-123")
+	cfg.Set("jira.user.token", "scoped-token")
+
+	client := &jira{
+		ViperConfigurableService: &config.ViperConfigurableService{Config: cfg, Prefix: "jira"},
+		allowPrompt:              false,
+	}
+
+	_, err := client.Authenticate()
+	require.NoError(t, err)
+	require.NotNil(t, client.client)
+
+	baseURL := client.client.GetBaseURL()
+	assert.Equal(t, "https://api.atlassian.com/ex/jira/cloud-123/", baseURL.String())
+}
+
+func TestAuthenticate_AtlassianCloudAPIURLPromptsForTokenOnly(t *testing.T) {
+	cfg := viper.New()
+	cfg.Set("jira.root", "https://api.atlassian.com/ex/jira/cloud-123")
+	cfg.Set("jira.user.login", "old-user@example.com")
+	cfg.Set("jira.token", `{"access_token":"old-oauth-token"}`)
+	cfg.SetConfigFile(filepath.Join(t.TempDir(), "config.yaml"))
+	require.NoError(t, cfg.WriteConfigAs(cfg.ConfigFileUsed()))
+
+	tokenPromptCalled := false
+	credentialsPromptCalled := false
+	client := &jira{
+		ViperConfigurableService: &config.ViperConfigurableService{Config: cfg, Prefix: "jira"},
+		allowPrompt:              true,
+		promptAPIToken: func() (string, error) {
+			tokenPromptCalled = true
+			return "scoped-token", nil
+		},
+		promptAPICreds: func() (string, string, error) {
+			credentialsPromptCalled = true
+			return "", "", fmt.Errorf("credential prompt should not be called")
+		},
+	}
+
+	origIsInputTerminalFn := isInputTerminalFn
+	isInputTerminalFn = func() bool { return true }
+	t.Cleanup(func() { isInputTerminalFn = origIsInputTerminalFn })
+
+	_, err := client.Authenticate()
+	require.NoError(t, err)
+	assert.True(t, tokenPromptCalled)
+	assert.False(t, credentialsPromptCalled)
+	assert.Equal(t, "", cfg.GetString("jira.user.login"))
+	assert.Equal(t, "scoped-token", cfg.GetString("jira.user.token"))
+	assert.Equal(t, "", cfg.GetString("jira.token"))
+	require.NotNil(t, client.client)
+}
+
 func TestAuthenticate_OAuthTokenWithoutCredentialsFallsBackToAuthRequiredWhenNonInteractive(t *testing.T) {
 	cfg := viper.New()
 	cfg.Set("jira.root", "https://acme.atlassian.net")

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -296,6 +296,7 @@ type jira struct {
 	promptRoot       func() (string, error)
 	promptAuthMethod func() (string, error)
 	promptAPICreds   func() (string, string, error)
+	promptAPIToken   func() (string, error)
 	metadataCache    cache.Store
 	cacheInitErr     error
 }
@@ -350,6 +351,17 @@ func (j *jira) Authenticate() (token *auth.AccessToken, err error) {
 	rootURL, err := j.resolveJiraRootURL()
 	if err != nil {
 		return nil, err
+	}
+
+	if isAtlassianCloudJiraAPIURL(rootURL) {
+		apiToken, hasAPIToken := j.configuredAPIToken()
+		if hasAPIToken {
+			return j.authenticateWithBearerToken(rootURL, apiToken)
+		}
+		if !j.allowPrompt || !isInputTerminalFn() {
+			return nil, ErrAuthRequired
+		}
+		return j.promptAndAuthenticateWithBearerToken(rootURL)
 	}
 
 	login, apiToken, hasAPICredentials := j.configuredAPICredentials()
@@ -445,6 +457,22 @@ func (j *jira) authenticateWithAPIToken(rootURL, login, token string) (*auth.Acc
 	return &auth.AccessToken{}, nil
 }
 
+func (j *jira) authenticateWithBearerToken(rootURL, token string) (*auth.AccessToken, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, ErrAuthRequired
+	}
+
+	transport := &jiraClient.BearerAuthTransport{Token: token}
+	jiraClientWithAuth, err := jiraClient.NewClient(wrapJiraHTTPClient(transport.Client()), rootURL)
+	if err != nil {
+		return nil, err
+	}
+
+	j.client = jiraClientWithAuth
+	return &auth.AccessToken{}, nil
+}
+
 func (j *jira) promptAndAuthenticateWithAPIToken(rootURL string, clearOAuthToken bool) (*auth.AccessToken, error) {
 	credentialsPrompt := j.promptAPICreds
 	if credentialsPrompt == nil {
@@ -468,15 +496,44 @@ func (j *jira) promptAndAuthenticateWithAPIToken(rootURL string, clearOAuthToken
 	return j.authenticateWithAPIToken(rootURL, promptLogin, promptToken)
 }
 
+func (j *jira) promptAndAuthenticateWithBearerToken(rootURL string) (*auth.AccessToken, error) {
+	tokenPrompt := j.promptAPIToken
+	if tokenPrompt == nil {
+		tokenPrompt = promptJiraAPIToken
+	}
+	promptToken, promptErr := tokenPrompt()
+	if promptErr != nil {
+		return nil, promptErr
+	}
+	if err := j.SaveConfig("user.login", ""); err != nil {
+		return nil, err
+	}
+	if err := j.SaveConfig("user.token", promptToken); err != nil {
+		return nil, err
+	}
+	if err := j.SaveConfig("token", ""); err != nil {
+		return nil, err
+	}
+	return j.authenticateWithBearerToken(rootURL, promptToken)
+}
+
 func (j *jira) configuredAPICredentials() (string, string, bool) {
 	login := strings.TrimSpace(j.GetConfigString("user.login"))
-	apiToken := strings.TrimSpace(j.GetConfigString("user.token"))
+	apiToken, hasAPIToken := j.configuredAPIToken()
 
-	if login == "" || apiToken == "" {
+	if login == "" || !hasAPIToken {
 		return "", "", false
 	}
 
 	return login, apiToken, true
+}
+
+func (j *jira) configuredAPIToken() (string, bool) {
+	apiToken := strings.TrimSpace(j.GetConfigString("user.token"))
+	if apiToken == "" {
+		return "", false
+	}
+	return apiToken, true
 }
 
 func (j *jira) hasStoredOAuthToken() bool {
@@ -531,6 +588,9 @@ func IsUnauthorizedError(err error) bool {
 func (j *jira) GetIssueURL(issueId string) string {
 	rootURL, err := j.resolveJiraRootURL()
 	if err != nil {
+		return ""
+	}
+	if isAtlassianCloudJiraAPIURL(rootURL) {
 		return ""
 	}
 	return fmt.Sprintf("%s/browse/%s", rootURL, strings.ToUpper(issueId))
@@ -1301,6 +1361,7 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error) {
 		promptRoot:               promptForJiraRootURL,
 		promptAuthMethod:         promptJiraAuthMethod,
 		promptAPICreds:           promptJiraAPICredentials,
+		promptAPIToken:           promptJiraAPIToken,
 		metadataCache:            metadataCache,
 		cacheInitErr:             cacheErr,
 		authenticator: createAuthenticator(func() string {
@@ -1328,7 +1389,7 @@ func (j *jira) resolveJiraRootURL() (string, error) {
 
 	configRoot := j.GetConfigString("root")
 	if configRoot != "" {
-		normalized, err := normalizeJiraRootURL(configRoot, false)
+		normalized, err := NormalizeRootURL(configRoot, false)
 		if err != nil {
 			return "", err
 		}
@@ -1353,7 +1414,7 @@ func (j *jira) resolveJiraRootURL() (string, error) {
 		return "", err
 	}
 
-	normalized, err := normalizeJiraRootURL(prompted, false)
+	normalized, err := NormalizeRootURL(prompted, false)
 	if err != nil {
 		return "", err
 	}
@@ -1376,9 +1437,9 @@ var (
 func promptForJiraRootURL() (string, error) {
 	input := ui.NewInputProgram(
 		ui.WithPrompt("Jira site URL"),
-		ui.WithPlaceholder("https://yourcompany.atlassian.net"),
+		ui.WithPlaceholder("https://yourcompany.atlassian.net or https://api.atlassian.com/ex/jira/{cloudId}"),
 		ui.WithValidation(func(value string) error {
-			_, err := normalizeJiraRootURL(value, false)
+			_, err := NormalizeRootURL(value, false)
 			return err
 		}),
 	)
@@ -1436,6 +1497,29 @@ func promptJiraAPICredentials() (string, string, error) {
 	return strings.TrimSpace(login), strings.TrimSpace(token), nil
 }
 
+func promptJiraAPIToken() (string, error) {
+	tokenInput := ui.NewInputProgram(
+		ui.WithPrompt("Jira API token (Atlassian)"),
+		ui.WithPlaceholder("Create a scoped token in Atlassian account security settings"),
+		ui.WithValidation(func(value string) error {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("jira api token is required")
+			}
+			return nil
+		}),
+	)
+
+	token, cancelled, err := tokenInput.RunWithCancel()
+	if err != nil {
+		return "", err
+	}
+	if cancelled || strings.TrimSpace(token) == "" {
+		return "", ErrAuthRequired
+	}
+
+	return strings.TrimSpace(token), nil
+}
+
 func promptJiraAuthMethod() (string, error) {
 	useOAuth, err := ui.Confirm("Authenticate Jira with OAuth? (No to use API token)", true)
 	if err != nil {
@@ -1447,7 +1531,9 @@ func promptJiraAuthMethod() (string, error) {
 	return jiraAuthMethodToken, nil
 }
 
-func normalizeJiraRootURL(raw string, allowHTTP bool) (string, error) {
+// NormalizeRootURL validates and normalizes a Jira site root URL or Atlassian
+// Cloud Jira API root URL.
+func NormalizeRootURL(raw string, allowHTTP bool) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return "", errMissingJiraRoot
@@ -1474,6 +1560,18 @@ func normalizeJiraRootURL(raw string, allowHTTP bool) (string, error) {
 		return "", fmt.Errorf("invalid Jira site URL: scheme must be https")
 	}
 
+	if normalizedAPIPath, ok := normalizeAtlassianCloudJiraAPIPath(parsed); ok {
+		parsed.Path = normalizedAPIPath
+		parsed.RawPath = ""
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		return strings.TrimRight(parsed.String(), "/"), nil
+	}
+
+	if strings.EqualFold(parsed.Host, "api.atlassian.com") {
+		return "", fmt.Errorf("invalid Jira site URL: Atlassian Cloud API URL must match https://api.atlassian.com/ex/jira/{cloudId}")
+	}
+
 	if parsed.Path != "" && parsed.Path != "/" {
 		return "", fmt.Errorf("invalid Jira site URL: path is not allowed")
 	}
@@ -1484,6 +1582,35 @@ func normalizeJiraRootURL(raw string, allowHTTP bool) (string, error) {
 	parsed.Fragment = ""
 
 	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func normalizeJiraRootURL(raw string, allowHTTP bool) (string, error) {
+	return NormalizeRootURL(raw, allowHTTP)
+}
+
+func isAtlassianCloudJiraAPIURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	_, ok := normalizeAtlassianCloudJiraAPIPath(parsed)
+	return ok
+}
+
+func normalizeAtlassianCloudJiraAPIPath(parsed *url.URL) (string, bool) {
+	if parsed == nil || !strings.EqualFold(parsed.Host, "api.atlassian.com") {
+		return "", false
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 3 {
+		return "", false
+	}
+	if parts[0] != "ex" || parts[1] != "jira" || strings.TrimSpace(parts[2]) == "" {
+		return "", false
+	}
+
+	return fmt.Sprintf("/ex/jira/%s", parts[2]), true
 }
 
 func isInputTerminal() bool {

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -1482,6 +1482,18 @@ func TestResolveJiraRootURL_NonInteractiveMissingConfig(t *testing.T) {
 	assert.ErrorIs(t, err, errMissingJiraRoot)
 }
 
+func TestGetIssueURL_AtlassianCloudAPIURLReturnsEmpty(t *testing.T) {
+	cfg := viper.New()
+	cfg.Set("jira.root", "https://api.atlassian.com/ex/jira/cloud-123")
+
+	j := &jira{
+		ViperConfigurableService: &config.ViperConfigurableService{Config: cfg, Prefix: "jira"},
+		allowPrompt:              false,
+	}
+
+	assert.Equal(t, "", j.GetIssueURL("TEST-123"))
+}
+
 func TestNormalizeJiraRootURL(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1492,7 +1504,12 @@ func TestNormalizeJiraRootURL(t *testing.T) {
 	}{
 		{name: "https with trailing slash", input: "https://acme.atlassian.net/", want: "https://acme.atlassian.net"},
 		{name: "missing scheme defaults to https", input: "acme.atlassian.net", want: "https://acme.atlassian.net"},
+		{name: "atlassian cloud jira api root", input: "https://api.atlassian.com/ex/jira/cloud-123/", want: "https://api.atlassian.com/ex/jira/cloud-123"},
+		{name: "atlassian cloud jira api root without scheme", input: "api.atlassian.com/ex/jira/cloud-123", want: "https://api.atlassian.com/ex/jira/cloud-123"},
 		{name: "path not allowed", input: "https://acme.atlassian.net/foo", wantErr: true},
+		{name: "atlassian cloud jira api rest path rejected", input: "https://api.atlassian.com/ex/jira/cloud-123/rest/api/3/project", wantErr: true},
+		{name: "atlassian cloud confluence api path rejected", input: "https://api.atlassian.com/ex/confluence/cloud-123/wiki", wantErr: true},
+		{name: "atlassian cloud jira api missing cloud id rejected", input: "https://api.atlassian.com/ex/jira", wantErr: true},
 		{name: "http rejected by default", input: "http://acme.atlassian.net", wantErr: true},
 		{name: "http allowed for tests", input: "http://localhost:9999", allowHTTP: true, want: "http://localhost:9999"},
 	}

--- a/pkg/commands/preflight.go
+++ b/pkg/commands/preflight.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tagoro9/fotingo/internal/commandruntime"
 	ftconfig "github.com/tagoro9/fotingo/internal/config"
 	fterrors "github.com/tagoro9/fotingo/internal/errors"
+	"github.com/tagoro9/fotingo/internal/jira"
 )
 
 type configRequirement = commandruntime.ConfigRequirement
@@ -23,7 +24,7 @@ func ensureJiraRootConfigured() error {
 		Key:         "jira.root",
 		EnvVar:      "FOTINGO_JIRA_ROOT",
 		Prompt:      "Jira site URL",
-		Placeholder: "https://yourcompany.atlassian.net",
+		Placeholder: "https://yourcompany.atlassian.net or https://api.atlassian.com/ex/jira/{cloudId}",
 		Validate:    normalizeJiraRootConfigValue,
 	})
 }
@@ -52,5 +53,5 @@ func defaultPromptForConfigValue(requirement configRequirement) (string, error) 
 }
 
 func normalizeJiraRootConfigValue(raw string) (string, error) {
-	return commandruntime.NormalizeHTTPSRootURL(raw, "jira site URL")
+	return jira.NormalizeRootURL(raw, false)
 }

--- a/pkg/commands/preflight_test.go
+++ b/pkg/commands/preflight_test.go
@@ -109,6 +109,10 @@ func TestNormalizeJiraRootConfigValue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://mycompany.atlassian.net", normalized)
 
+	normalized, err = normalizeJiraRootConfigValue("https://api.atlassian.com/ex/jira/cloud-123/")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.atlassian.com/ex/jira/cloud-123", normalized)
+
 	_, err = normalizeJiraRootConfigValue("http://mycompany.atlassian.net")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "scheme must be https")

--- a/pkg/commands/review_stacks.go
+++ b/pkg/commands/review_stacks.go
@@ -13,6 +13,7 @@ import (
 	internalreview "github.com/tagoro9/fotingo/internal/commands/review"
 	"github.com/tagoro9/fotingo/internal/git"
 	"github.com/tagoro9/fotingo/internal/github"
+	"github.com/tagoro9/fotingo/internal/jira"
 )
 
 type reviewStacksFlags struct {
@@ -438,7 +439,7 @@ func reviewStackJiraURL(jiraKey string) string {
 	if key == "" {
 		return ""
 	}
-	root, err := commandruntime.NormalizeHTTPSRootURL(fotingoConfig.GetString("jira.root"), "jira root")
+	root, err := jira.NormalizeRootURL(fotingoConfig.GetString("jira.root"), false)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
FOTINGO-51: Support using atlassian cloud service accounts
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Authentication is slightly different, as the endpoint changes and it uses a bearer token instead of user + token:


{noformat}## URLs for API tokens with scopes for Jira 
curl -v \
  https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/project \
  -H "Authorization: Bearer my-api-token" \
  -H "Accept: application/json"
## URLs for API tokens with scopes for Confluence
curl -v \
  https://api.atlassian.com/ex/confluence/{cloudId}/wiki/rest/api/space \
  -H "Authorization: Bearer my-api-token" \
  -H "Accept: application/json"
 {noformat}

We can still require users to provide the base URL, which should contain the cloudId in it. Based on the value of the URL, we can decide to use current auth or bearer token. 

For the interactive setup, we first ask about the URL and then based on that we decide if we need to ask for the user + api key or just the token.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
Fixes [FOTINGO-51](https://tagoro9.atlassian.net/browse/FOTINGO-51)
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* feat(jira): support Atlassian Cloud service accounts (+256/-23)
* docs(jira): refresh generated gomarkdoc links (+6/-6)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)