### PR TITLE
[FOTINGO-52] When fotingo creates a PR with a atlassian cloud config, it doesn't add the URL to the fixed tickets section, but only plain text. It should still include tickets with URLs

### DIFF
--- a/docs/automation-and-json.md
+++ b/docs/automation-and-json.md
@@ -71,7 +71,7 @@ fotingo review stacks rebase --json
 fotingo review stacks rebase --push --json
 ```
 
-Automation should run stack rebase only when it is prepared to handle conflicts. The command requires clean worktrees before starting and stops at the first failed rebase; `--push` is the explicit opt-in for force-with-lease pushes.
+Automation should run stack rebase only when it is prepared to handle conflicts. The command requires clean worktrees before starting and stops at the first failed rebase. If earlier stack PRs have been merged, remaining PRs are rebased onto the native stack base branch. `--push` is the explicit opt-in for force-with-lease pushes.
 
 ## JSON Schemas
 

--- a/docs/automation-and-json.md
+++ b/docs/automation-and-json.md
@@ -58,7 +58,7 @@ Use the global `--branch` flag when the automation needs to target a non-default
 fotingo review -y --branch release/2026.04
 ```
 
-When that base branch already has an open PR, `fotingo review -y --branch <parent-branch>` creates a stacked child PR and updates the stack section across the open stack. To refresh stack sections later without prompting:
+When that base branch already has an open PR, `fotingo review -y --branch <parent-branch>` creates a stacked child PR and creates or extends the GitHub-native stack. To refresh native stack state later without prompting:
 
 ```bash
 fotingo review stacks sync --json

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -172,7 +172,7 @@ fotingo review sync -r alice --remove-reviewers team/platform -a bob --remove-as
 Notes:
 
 - Use the global `--branch` / `-b` flag to override the pull request base branch when the PR should target something other than the repository default branch.
-- When `--branch` targets a branch that already has an open PR, `review` treats the new PR as a stacked child, creates or reuses stack metadata, and updates the `Stacked PRs` section across the open stack.
+- When `--branch` targets a branch that already has an open PR, `review` treats the new PR as a stacked child and creates or extends the GitHub-native pull request stack.
 - Use `--template-summary` and `--template-description` to fill the default PR template sections.
 - `--template-description` expands escaped `\n`, `\r\n`, and `\t`, which makes multiline scripted descriptions reliable.
 - Use `--description` when you want to replace the entire PR body instead of filling template placeholders.
@@ -180,7 +180,7 @@ Notes:
 - Use `fotingo review sync -r ... --remove-reviewers ... -a ... --remove-assignee ...` to update reviewers and assignees on an existing PR.
 - Use `fotingo review sync --ready-for-review` to move an existing draft PR to ready for review without recreating it.
 - Resolve reviewers, assignees, and labels ahead of time with `fotingo search ... --json` when scripting review creation.
-- Stacked PR sections render Jira keys and PR links. The current PR is marked after the order number with `👉`.
+- Stack membership and ordering are provided by GitHub's native pull request stack API.
 
 #### `review stacks`
 
@@ -195,7 +195,7 @@ Subcommands:
 | Command                               | Description                                                                                |
 | ------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `fotingo review stacks`               | Print the current branch's stack members in root-to-leaf order, marking the current PR     |
-| `fotingo review stacks sync`          | Recompute and update the deterministic stacked PR section for every open PR in the stack   |
+| `fotingo review stacks sync`          | Refresh native stack state without editing pull request bodies                             |
 | `fotingo review stacks rebase`        | Rebase local stack branches in order, using each branch's existing worktree when available |
 | `fotingo review stacks rebase --push` | Push rebased stack branches with `--force-with-lease` after successful local rebases       |
 
@@ -203,7 +203,7 @@ Notes:
 
 - Stack commands default to the stack that contains the current branch's open PR.
 - `review stacks` prints a terminal table with clickable Jira and pull request labels in terminals that support links, not Markdown table syntax.
-- `review stacks sync` does not open an editor; it only rewrites the marker-owned `stacked-prs` section.
+- `review stacks sync` does not open an editor or rewrite pull request bodies.
 - `review stacks rebase` requires every branch that will be rebased to have a clean local worktree and stops at the first rebase conflict.
 - Branches in separate linked worktrees are supported; fotingo discovers them with Git worktree metadata and runs each rebase in that branch's worktree.
 - Branching stacks are not supported in this iteration. If one PR branch has multiple stack children, fotingo fails before updating PR bodies.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -204,7 +204,7 @@ Notes:
 - Stack commands default to the stack that contains the current branch's open PR.
 - `review stacks` prints a terminal table with clickable Jira and pull request labels in terminals that support links, not Markdown table syntax.
 - `review stacks sync` does not open an editor or rewrite pull request bodies.
-- `review stacks rebase` requires every branch that will be rebased to have a clean local worktree and stops at the first rebase conflict.
+- `review stacks rebase` requires every branch that will be rebased to have a clean local worktree and stops at the first rebase conflict. If earlier stack PRs have been merged, the remaining PRs are rebased onto the native stack's base branch.
 - Branches in separate linked worktrees are supported; fotingo discovers them with Git worktree metadata and runs each rebase in that branch's worktree.
 - Branching stacks are not supported in this iteration. If one PR branch has multiple stack children, fotingo fails before updating PR bodies.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,7 @@ PR template resolution order:
 2. Standard GitHub PR template locations (`.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or `pull_request_template.md`)
 3. Built-in default template
 
-The default template uses fotingo-managed HTML comment markers for `summary`, `description`, `fixed-issues`, `changes`, and an initially empty `stacked-prs` range, plus the `{fotingo.banner}` placeholder.
+The default template uses fotingo-managed HTML comment markers for `summary`, `description`, `fixed-issues`, and `changes`, plus the `{fotingo.banner}` placeholder. Stack membership is managed by GitHub's native pull request stack API.
 
 Repository templates can use the same marker pairs:
 
@@ -114,8 +114,5 @@ Repository templates can use the same marker pairs:
 - `<!-- fotingo:start description -->` / `<!-- fotingo:end description -->`
 - `<!-- fotingo:start fixed-issues -->` / `<!-- fotingo:end fixed-issues -->`
 - `<!-- fotingo:start changes -->` / `<!-- fotingo:end changes -->`
-- `<!-- fotingo:start stacked-prs -->` / `<!-- fotingo:end stacked-prs -->`
-
-Keep the `stacked-prs` marker range empty in templates. Fotingo renders the visible `Stacked PRs` table only after a PR becomes part of a stack. Stack sync commands rewrite only that marker-owned range and preserve content outside it.
 
 Legacy managed placeholders such as `{summary}`, `{description}`, `{fixedIssues}`, and `{changes}` are still supported for backward compatibility, but they are deprecated.

--- a/internal/commands/ai/skills/fotingo-core.md
+++ b/internal/commands/ai/skills/fotingo-core.md
@@ -135,7 +135,7 @@ Rebase stack branches in their existing local worktrees:
 - For current-branch PR discussion context, run `fotingo inspect pr --json` and read `pullRequest`, top-level `comments`, and `reviews[].conversations[].comments` before deciding whether to call `fotingo review sync`, `fotingo open pr`, or `fotingo review`.
 - Prefer `fotingo review -y` for the standard Jira-backed flow. Use `fotingo review -y --simple` only when you intentionally want a GitHub-only PR flow.
 - Use `fotingo review --branch ...` when the pull request should target a non-default base branch.
-- Use `fotingo review --branch <parent-branch>` to create a stacked child PR when `<parent-branch>` already has an open PR. Fotingo updates stack metadata and stacked PR sections automatically in that case.
+- Use `fotingo review --branch <parent-branch>` to create a stacked child PR when `<parent-branch>` already has an open PR. Fotingo creates or extends the GitHub-native pull request stack automatically in that case.
 - Prefer `--template-summary` and `--template-description` because they keep the default PR layout while filling the `Summary` and `Description` sections. `--template-description` expands escaped `\n`, `\r\n`, and `\t`.
 - Use `fotingo review sync -y` after follow-up commits to refresh fotingo-managed sections while preserving manual edits outside the managed placeholders.
 - Use `fotingo review sync --section ...` to limit which managed sections are rewritten. Supported section values are `summary`, `description`, `fixed-issues`, and `changes`, and shell completion can suggest them. `--template-summary` and `--template-description` only apply when those sections are included in the sync.

--- a/internal/commands/ai/testdata/skill_codex.golden
+++ b/internal/commands/ai/testdata/skill_codex.golden
@@ -150,7 +150,7 @@ fotingo review stacks rebase --json
 - For current-branch PR discussion context, run `fotingo inspect pr --json` and read `pullRequest`, top-level `comments`, and `reviews[].conversations[].comments` before deciding whether to call `fotingo review sync`, `fotingo open pr`, or `fotingo review`.
 - Prefer `fotingo review -y` for the standard Jira-backed flow. Use `fotingo review -y --simple` only when you intentionally want a GitHub-only PR flow.
 - Use `fotingo review --branch ...` when the pull request should target a non-default base branch.
-- Use `fotingo review --branch <parent-branch>` to create a stacked child PR when `<parent-branch>` already has an open PR. Fotingo updates stack metadata and stacked PR sections automatically in that case.
+- Use `fotingo review --branch <parent-branch>` to create a stacked child PR when `<parent-branch>` already has an open PR. Fotingo creates or extends the GitHub-native pull request stack automatically in that case.
 - Prefer `--template-summary` and `--template-description` because they keep the default PR layout while filling the `Summary` and `Description` sections. `--template-description` expands escaped `\n`, `\r\n`, and `\t`.
 - Use `fotingo review sync -y` after follow-up commits to refresh fotingo-managed sections while preserving manual edits outside the managed placeholders.
 - Use `fotingo review sync --section ...` to limit which managed sections are rewritten. Supported section values are `summary`, `description`, `fixed-issues`, and `changes`, and shell completion can suggest them. `--template-summary` and `--template-description` only apply when those sections are included in the sync.

--- a/internal/commands/ai/testdata/skill_cursor.golden
+++ b/internal/commands/ai/testdata/skill_cursor.golden
@@ -150,7 +150,7 @@ fotingo review stacks rebase --json
 - For current-branch PR discussion context, run `fotingo inspect pr --json` and read `pullRequest`, top-level `comments`, and `reviews[].conversations[].comments` before deciding whether to call `fotingo review sync`, `fotingo open pr`, or `fotingo review`.
 - Prefer `fotingo review -y` for the standard Jira-backed flow. Use `fotingo review -y --simple` only when you intentionally want a GitHub-only PR flow.
 - Use `fotingo review --branch ...` when the pull request should target a non-default base branch.
-- Use `fotingo review --branch <parent-branch>` to create a stacked child PR when `<parent-branch>` already has an open PR. Fotingo updates stack metadata and stacked PR sections automatically in that case.
+- Use `fotingo review --branch <parent-branch>` to create a stacked child PR when `<parent-branch>` already has an open PR. Fotingo creates or extends the GitHub-native pull request stack automatically in that case.
 - Prefer `--template-summary` and `--template-description` because they keep the default PR layout while filling the `Summary` and `Description` sections. `--template-description` expands escaped `\n`, `\r\n`, and `\t`.
 - Use `fotingo review sync -y` after follow-up commits to refresh fotingo-managed sections while preserving manual edits outside the managed placeholders.
 - Use `fotingo review sync --section ...` to limit which managed sections are rewritten. Supported section values are `summary`, `description`, `fixed-issues`, and `changes`, and shell completion can suggest them. `--template-summary` and `--template-description` only apply when those sections are included in the sync.

--- a/internal/commands/review/README.md
+++ b/internal/commands/review/README.md
@@ -843,7 +843,7 @@ type WorkflowResult struct {
 ```
 
 <a name="WorkflowRunner"></a>
-## type [WorkflowRunner](<https://github.com/tagoro9/fotingo/blob/main/internal/commands/review/workflow.go#L81-L86>)
+## type [WorkflowRunner](<https://github.com/tagoro9/fotingo/blob/main/internal/commands/review/workflow.go#L79-L84>)
 
 WorkflowRunner executes the review command workflow.
 
@@ -857,7 +857,7 @@ type WorkflowRunner struct {
 ```
 
 <a name="WorkflowRunner.Run"></a>
-### func \(WorkflowRunner\) [Run](<https://github.com/tagoro9/fotingo/blob/main/internal/commands/review/workflow.go#L89>)
+### func \(WorkflowRunner\) [Run](<https://github.com/tagoro9/fotingo/blob/main/internal/commands/review/workflow.go#L87>)
 
 ```go
 func (r WorkflowRunner) Run(statusCh *chan string, out WorkflowEmitter, allowEditor bool) WorkflowResult

--- a/internal/commands/review/workflow.go
+++ b/internal/commands/review/workflow.go
@@ -301,7 +301,11 @@ func (r WorkflowRunner) Run(statusCh *chan string, out WorkflowEmitter, allowEdi
 
 	if shouldCollectReviewCommits(r.Options.Description) {
 		collectCommitsStart := time.Now()
-		loadedCommits, commitErr := collectReviewCommits(gitClient, stackParentPR != nil, stackBaseBranch)
+		commitBase := stackBaseBranch
+		if stackParentPR != nil && strings.TrimSpace(stackParentPR.HeadSHA) != "" {
+			commitBase = stackParentPR.HeadSHA
+		}
+		loadedCommits, commitErr := collectReviewCommits(gitClient, stackParentPR != nil, commitBase)
 		logReviewPhaseTiming(out, "collect_commits", collectCommitsStart)
 		if commitErr != nil {
 			out.Debugf("review commits unavailable: %v", commitErr)

--- a/internal/commands/review/workflow.go
+++ b/internal/commands/review/workflow.go
@@ -73,8 +73,6 @@ type WorkflowDeps struct {
 
 type stackGitHubClient interface {
 	FindOpenPullRequestByHeadBranch(string) (*github.PullRequest, bool, error)
-	ListOpenPullRequestsByStackID(string) ([]github.PullRequest, error)
-	UpdatePullRequestBodies([]github.PullRequestBodyUpdate) ([]*github.PullRequest, error)
 }
 
 // WorkflowRunner executes the review command workflow.
@@ -156,6 +154,8 @@ func (r WorkflowRunner) Run(statusCh *chan string, out WorkflowEmitter, allowEdi
 
 	stackBaseBranch := strings.TrimSpace(r.Options.BaseBranch)
 	var stackParentPR *github.PullRequest
+	var stack *github.PullRequestStack
+	var nativeStackClient github.NativeStackClient
 	var stackClient stackGitHubClient
 	if stackBaseBranch != "" {
 		if candidate, ok := ghClient.(stackGitHubClient); ok {
@@ -167,6 +167,24 @@ func (r WorkflowRunner) Run(statusCh *chan string, out WorkflowEmitter, allowEdi
 			}
 			if parentExists {
 				stackParentPR = parentPR
+				candidate, nativeOK := ghClient.(github.NativeStackClient)
+				if !nativeOK {
+					result.Err = fterrors.WrapGitHubError("failed to update native pull request stack", fmt.Errorf("github client does not support native pull request stacks"))
+					return result
+				}
+				nativeStackClient = candidate
+				stacks, stackErr := nativeStackClient.ListPullRequestStacks(parentPR.Number)
+				if stackErr != nil {
+					result.Err = fterrors.WrapGitHubError(t(i18n.ReviewWrapCheckExistingPR), stackErr)
+					return result
+				}
+				if len(stacks) > 1 {
+					result.Err = fterrors.WrapGitHubError("failed to identify parent pull request stack", fmt.Errorf("pull request #%d belongs to %d stacks", parentPR.Number, len(stacks)))
+					return result
+				}
+				if len(stacks) == 1 {
+					stack = &stacks[0]
+				}
 				out.InfoRaw("review", fmt.Sprintf("Stack mode enabled: base branch %s is pull request #%d", stackBaseBranch, parentPR.Number))
 				out.Debugf("review stack parent pr=%d branch=%s", parentPR.Number, stackBaseBranch)
 			}
@@ -355,15 +373,23 @@ func (r WorkflowRunner) Run(statusCh *chan string, out WorkflowEmitter, allowEdi
 	result.PR = pr
 	out.Info("rocket", i18n.ReviewStatusPRCreated, pr.HTMLURL)
 
-	if stackParentPR != nil && stackClient != nil {
-		out.InfoRaw("progress", fmt.Sprintf("Updating stacked PR sections for parent #%d and new PR #%d", stackParentPR.Number, pr.Number))
-		if updatedStackPR, stackErr := updateStackedPRSections(stackClient, jiraClient, stackParentPR, pr); stackErr != nil {
-			result.Err = fterrors.WrapGitHubError("failed to update stacked pull request sections", stackErr)
-			return result
-		} else if updatedStackPR != nil {
-			result.PR = updatedStackPR
+	if stackParentPR != nil && nativeStackClient != nil {
+		out.InfoRaw("progress", fmt.Sprintf("Adding pull request #%d to native stack", pr.Number))
+		var stackErr error
+		if stack != nil {
+			if len(stack.PullRequests) == 0 || stack.PullRequests[len(stack.PullRequests)-1].Number != stackParentPR.Number {
+				result.Err = fterrors.WrapGitHubError("failed to update native pull request stack", fmt.Errorf("parent pull request #%d is not the current native stack top", stackParentPR.Number))
+				return result
+			}
+			_, stackErr = nativeStackClient.AddPullRequestsToStack(stack.Number, []int{pr.Number})
+		} else {
+			_, stackErr = nativeStackClient.CreatePullRequestStack([]int{stackParentPR.Number, pr.Number})
 		}
-		out.InfoRaw("check", "Stacked PR sections updated")
+		if stackErr != nil {
+			result.Err = fterrors.WrapGitHubError("failed to update native pull request stack", stackErr)
+			return result
+		}
+		out.InfoRaw("check", "Native pull request stack updated")
 	}
 
 	if len(resolvedReviewers) > 0 || len(resolvedTeamReviewers) > 0 {
@@ -479,93 +505,6 @@ func collectReviewCommits(gitClient reviewCommitCollector, useBaseBranch bool, b
 		return nil, fmt.Errorf("failed to get commits since base branch %s: %w", baseBranch, err)
 	}
 	return gitClient.GetCommitsSinceDefaultBranch()
-}
-
-func updateStackedPRSections(
-	stackClient stackGitHubClient,
-	jiraClient jira.Jira,
-	parentPR *github.PullRequest,
-	childPR *github.PullRequest,
-) (*github.PullRequest, error) {
-	if stackClient == nil || parentPR == nil || childPR == nil {
-		return childPR, nil
-	}
-
-	stackID := ExtractStackID(parentPR.Body)
-	if stackID == "" {
-		stackID = StackIDForRootPR(parentPR.Number, parentPR.HTMLURL)
-	}
-
-	members := []github.PullRequest{*parentPR}
-	if existingMembers, err := stackClient.ListOpenPullRequestsByStackID(stackID); err != nil {
-		return nil, err
-	} else if len(existingMembers) > 0 {
-		members = existingMembers
-	}
-	members = appendStackMember(members, *parentPR)
-	members = appendStackMember(members, *childPR)
-	orderedMembers, err := OrderStackPullRequests(members)
-	if err != nil {
-		return nil, err
-	}
-
-	updates := make([]github.PullRequestBodyUpdate, 0, len(orderedMembers))
-	for _, member := range orderedMembers {
-		body, err := ReplaceStackedPRSectionContent(
-			member.Body,
-			RenderStackedPRSection(StackRenderOptions{
-				StackID: stackID,
-				Items:   stackPRItems(orderedMembers, member.Number, jiraClient),
-			}),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("pull request #%d: %w", member.Number, err)
-		}
-		updates = append(updates, github.PullRequestBodyUpdate{Number: member.Number, Body: body})
-	}
-
-	updated, err := stackClient.UpdatePullRequestBodies(updates)
-	if err != nil {
-		return nil, err
-	}
-	for _, candidate := range updated {
-		if candidate != nil && candidate.Number == childPR.Number {
-			return candidate, nil
-		}
-	}
-	return childPR, nil
-}
-
-func appendStackMember(members []github.PullRequest, pr github.PullRequest) []github.PullRequest {
-	for _, member := range members {
-		if member.Number == pr.Number {
-			return members
-		}
-	}
-	return append(members, pr)
-}
-
-func stackPRItems(members []github.PullRequest, currentNumber int, jiraClient jira.Jira) []StackPullRequest {
-	items := make([]StackPullRequest, 0, len(members))
-	for _, member := range members {
-		jiraKey := DeriveStackJiraKey(member.HeadRef, member.Title, member.Body)
-		jiraURL := ""
-		if jiraClient != nil && jiraKey != "" {
-			jiraURL = jiraClient.GetIssueURL(jiraKey)
-		}
-		items = append(items, StackPullRequest{
-			Number:  member.Number,
-			Title:   member.Title,
-			HTMLURL: member.HTMLURL,
-			JiraKey: jiraKey,
-			JiraURL: jiraURL,
-			State:   member.State,
-			Draft:   member.Draft,
-			Merged:  member.Merged,
-			Current: member.Number == currentNumber,
-		})
-	}
-	return items
 }
 
 func logReviewPhaseTiming(out WorkflowEmitter, phase string, start time.Time) {

--- a/internal/commands/review/workflow_test.go
+++ b/internal/commands/review/workflow_test.go
@@ -165,6 +165,9 @@ type workflowSuccessMockGitHub struct {
 	pr              *github.PullRequest
 	parentPR        *github.PullRequest
 	stackMembers    []github.PullRequest
+	nativeStack     *github.PullRequestStack
+	createdStack    []int
+	addedToStack    []int
 	bodyUpdates     []github.PullRequestBodyUpdate
 	createPROptions github.CreatePROptions
 }
@@ -217,6 +220,20 @@ func (m workflowSuccessMockGitHub) FindOpenPullRequestByHeadBranch(string) (*git
 }
 func (m workflowSuccessMockGitHub) ListOpenPullRequestsByStackID(string) ([]github.PullRequest, error) {
 	return append([]github.PullRequest(nil), m.stackMembers...), nil
+}
+func (m *workflowSuccessMockGitHub) ListPullRequestStacks(int) ([]github.PullRequestStack, error) {
+	if m.nativeStack == nil {
+		return nil, nil
+	}
+	return []github.PullRequestStack{*m.nativeStack}, nil
+}
+func (m *workflowSuccessMockGitHub) CreatePullRequestStack(numbers []int) (*github.PullRequestStack, error) {
+	m.createdStack = append([]int(nil), numbers...)
+	return m.nativeStack, nil
+}
+func (m *workflowSuccessMockGitHub) AddPullRequestsToStack(_ int, numbers []int) (*github.PullRequestStack, error) {
+	m.addedToStack = append([]int(nil), numbers...)
+	return m.nativeStack, nil
 }
 func (m *workflowSuccessMockGitHub) UpdatePullRequestBodies(updates []github.PullRequestBodyUpdate) ([]*github.PullRequest, error) {
 	m.bodyUpdates = append([]github.PullRequestBodyUpdate(nil), updates...)
@@ -435,17 +452,11 @@ func TestWorkflowRunnerRun_UpdatesStackSectionsWhenBaseBranchHasPR(t *testing.T)
 
 	require.NoError(t, result.Err)
 	assert.Equal(t, "feature/ABC-1-parent", ghClient.createPROptions.Base)
-	require.Len(t, ghClient.bodyUpdates, 2)
-	assert.Equal(t, 12, ghClient.bodyUpdates[0].Number)
-	assert.Equal(t, 13, ghClient.bodyUpdates[1].Number)
-	assert.Contains(t, ghClient.bodyUpdates[0].Body, `<!-- fotingo:stack id="testowner/testrepo#12" version="1" -->`)
-	assert.Contains(t, ghClient.bodyUpdates[0].Body, "| 1 👉 | ABC-1 | [#12 ABC-1 Parent](https://github.com/testowner/testrepo/pull/12) |")
-	assert.Contains(t, ghClient.bodyUpdates[0].Body, "| 2   | ABC-2 | [#13 ABC-2 Child](https://github.com/testowner/testrepo/pull/13) |")
-	assert.Contains(t, ghClient.bodyUpdates[1].Body, "| 1   | ABC-1 | [#12 ABC-1 Parent](https://github.com/testowner/testrepo/pull/12) |")
-	assert.Contains(t, ghClient.bodyUpdates[1].Body, "| 2 👉 | ABC-2 | [#13 ABC-2 Child](https://github.com/testowner/testrepo/pull/13) |")
+	assert.Equal(t, []int{12, 13}, ghClient.createdStack)
+	assert.Empty(t, ghClient.bodyUpdates)
 	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Stack mode enabled: base branch feature/ABC-1-parent is pull request #12")
-	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Updating stacked PR sections for parent #12 and new PR #13")
-	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Stacked PR sections updated")
+	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Adding pull request #13 to native stack")
+	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Native pull request stack updated")
 	assert.Equal(t, "feature/ABC-1-parent", gitClient.commitsSinceRef)
 	assert.False(t, gitClient.defaultCommits)
 }
@@ -483,16 +494,15 @@ func TestWorkflowRunnerRun_ExtendsExistingStackSections(t *testing.T) {
 		pr:           child,
 		parentPR:     parent,
 		stackMembers: []github.PullRequest{root, middle},
+		nativeStack:  &github.PullRequestStack{Number: 42, PullRequests: []github.PullRequest{root, middle}},
 	}
 	runner := stackWorkflowRunner(&stackWorkflowMockGit{}, ghClient, WorkflowOptions{Simple: true, BaseBranch: "feature/ABC-2-middle"})
 
 	result := runner.Run(nil, nil, false)
 
 	require.NoError(t, result.Err)
-	require.Len(t, ghClient.bodyUpdates, 3)
-	assert.Equal(t, []int{12, 13, 14}, []int{ghClient.bodyUpdates[0].Number, ghClient.bodyUpdates[1].Number, ghClient.bodyUpdates[2].Number})
-	assert.Contains(t, ghClient.bodyUpdates[2].Body, `<!-- fotingo:stack id="testowner/testrepo#12" version="1" -->`)
-	assert.Contains(t, ghClient.bodyUpdates[2].Body, "| 3 👉 | ABC-3 | [#14 ABC-3 Child](https://github.com/testowner/testrepo/pull/14) |")
+	assert.Equal(t, []int{14}, ghClient.addedToStack)
+	assert.Empty(t, ghClient.bodyUpdates)
 }
 
 func assertStackWorkflowRawEvent(t *testing.T, events []reviewRawEvent, message string) {

--- a/internal/commands/review/workflow_test.go
+++ b/internal/commands/review/workflow_test.go
@@ -431,6 +431,7 @@ func TestWorkflowRunnerRun_UpdatesStackSectionsWhenBaseBranchHasPR(t *testing.T)
 		Body:    "<!-- fotingo:start stacked-prs -->\n<!-- fotingo:end stacked-prs -->",
 		HTMLURL: "https://github.com/testowner/testrepo/pull/12",
 		HeadRef: "feature/ABC-1-parent",
+		HeadSHA: "parent-head-sha",
 		BaseRef: "main",
 		State:   "open",
 	}
@@ -457,7 +458,7 @@ func TestWorkflowRunnerRun_UpdatesStackSectionsWhenBaseBranchHasPR(t *testing.T)
 	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Stack mode enabled: base branch feature/ABC-1-parent is pull request #12")
 	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Adding pull request #13 to native stack")
 	assertStackWorkflowRawEvent(t, emitter.rawEvents, "Native pull request stack updated")
-	assert.Equal(t, "feature/ABC-1-parent", gitClient.commitsSinceRef)
+	assert.Equal(t, "parent-head-sha", gitClient.commitsSinceRef)
 	assert.False(t, gitClient.defaultCommits)
 }
 

--- a/internal/github/README.md
+++ b/internal/github/README.md
@@ -31,6 +31,7 @@ import "github.com/tagoro9/fotingo/internal/github"
   - [func GroupPullRequestReviewComments\(comments \[\]PullRequestReviewComment\) \[\]PullRequestConversation](<#GroupPullRequestReviewComments>)
 - [type PullRequestDiscussion](<#PullRequestDiscussion>)
 - [type PullRequestIssueComment](<#PullRequestIssueComment>)
+- [type PullRequestLoader](<#PullRequestLoader>)
 - [type PullRequestReview](<#PullRequestReview>)
 - [type PullRequestReviewComment](<#PullRequestReviewComment>)
 - [type PullRequestStack](<#PullRequestStack>)
@@ -56,7 +57,7 @@ var ErrOAuthClientIDMissing = errors.New("github oauth client id is missing in t
 ```
 
 <a name="FetchLatestReleaseTag"></a>
-## func [FetchLatestReleaseTag](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1359>)
+## func [FetchLatestReleaseTag](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1383>)
 
 ```go
 func FetchLatestReleaseTag(ctx context.Context, client *http.Client, owner string, repo string) (string, error)
@@ -80,7 +81,7 @@ type CreatePROptions struct {
 ```
 
 <a name="CreateReleaseOptions"></a>
-## type [CreateReleaseOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L172-L179>)
+## type [CreateReleaseOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L173-L180>)
 
 CreateReleaseOptions contains the options for creating a release
 
@@ -96,7 +97,7 @@ type CreateReleaseOptions struct {
 ```
 
 <a name="Github"></a>
-## type [Github](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L190-L227>)
+## type [Github](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L191-L228>)
 
 
 
@@ -142,7 +143,7 @@ type Github interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1712>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1737>)
 
 ```go
 func New(git git.Git, cfg *viper.Viper) (Github, error)
@@ -151,7 +152,7 @@ func New(git git.Git, cfg *viper.Viper) (Github, error)
 
 
 <a name="NewAuthOnly"></a>
-### func [NewAuthOnly](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1716>)
+### func [NewAuthOnly](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1741>)
 
 ```go
 func NewAuthOnly(cfg *viper.Viper) (Github, error)
@@ -160,7 +161,7 @@ func NewAuthOnly(cfg *viper.Viper) (Github, error)
 
 
 <a name="NewAuthOnlyWithOptions"></a>
-### func [NewAuthOnlyWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1720>)
+### func [NewAuthOnlyWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1745>)
 
 ```go
 func NewAuthOnlyWithOptions(cfg *viper.Viper, allowPrompt bool) (Github, error)
@@ -169,7 +170,7 @@ func NewAuthOnlyWithOptions(cfg *viper.Viper, allowPrompt bool) (Github, error)
 
 
 <a name="NewWithHTTPClient"></a>
-### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1659>)
+### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1684>)
 
 ```go
 func NewWithHTTPClient(g git.Git, cfg *viper.Viper, httpClient *http.Client, baseURL string) (Github, error)
@@ -178,7 +179,7 @@ func NewWithHTTPClient(g git.Git, cfg *viper.Viper, httpClient *http.Client, bas
 NewWithHTTPClient returns a new GitHub client using the provided HTTP client and base URL. This bypasses OAuth authentication and is intended for testing with mock servers.
 
 <a name="NewWithHTTPClientAndRepo"></a>
-### func [NewWithHTTPClientAndRepo](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1688>)
+### func [NewWithHTTPClientAndRepo](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1713>)
 
 ```go
 func NewWithHTTPClientAndRepo(g git.Git, cfg *viper.Viper, httpClient *http.Client, baseURL, owner, repo string) (Github, error)
@@ -187,7 +188,7 @@ func NewWithHTTPClientAndRepo(g git.Git, cfg *viper.Viper, httpClient *http.Clie
 NewWithHTTPClientAndRepo creates a GitHub client with explicit owner/repo, bypassing remote URL parsing.
 
 <a name="NewWithOptions"></a>
-### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1768>)
+### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1793>)
 
 ```go
 func NewWithOptions(git git.Git, cfg *viper.Viper, allowPrompt bool) (Github, error)
@@ -196,7 +197,7 @@ func NewWithOptions(git git.Git, cfg *viper.Viper, allowPrompt bool) (Github, er
 
 
 <a name="GithubConfig"></a>
-## type [GithubConfig](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L247-L249>)
+## type [GithubConfig](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L253-L255>)
 
 
 
@@ -207,7 +208,7 @@ type GithubConfig struct {
 ```
 
 <a name="Label"></a>
-## type [Label](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L141-L145>)
+## type [Label](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L142-L146>)
 
 Label represents a GitHub label
 
@@ -220,7 +221,7 @@ type Label struct {
 ```
 
 <a name="NativeStackClient"></a>
-## type [NativeStackClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L230-L234>)
+## type [NativeStackClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L231-L235>)
 
 NativeStackClient is implemented by GitHub clients that support native PR stacks.
 
@@ -233,7 +234,7 @@ type NativeStackClient interface {
 ```
 
 <a name="PullRequest"></a>
-## type [PullRequest](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L54-L67>)
+## type [PullRequest](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L54-L68>)
 
 PullRequest represents a GitHub pull request
 
@@ -246,6 +247,7 @@ type PullRequest struct {
     URL       string
     HTMLURL   string
     HeadRef   string
+    HeadSHA   string
     BaseRef   string
     Draft     bool
     State     string
@@ -267,7 +269,7 @@ type PullRequestBodyUpdate struct {
 ```
 
 <a name="PullRequestConversation"></a>
-## type [PullRequestConversation](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L134-L138>)
+## type [PullRequestConversation](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L135-L139>)
 
 PullRequestConversation groups related inline review comments.
 
@@ -280,7 +282,7 @@ type PullRequestConversation struct {
 ```
 
 <a name="GroupPullRequestReviewComments"></a>
-### func [GroupPullRequestReviewComments](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L656>)
+### func [GroupPullRequestReviewComments](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L680>)
 
 ```go
 func GroupPullRequestReviewComments(comments []PullRequestReviewComment) []PullRequestConversation
@@ -289,7 +291,7 @@ func GroupPullRequestReviewComments(comments []PullRequestReviewComment) []PullR
 GroupPullRequestReviewComments groups inline review comments into conversation\-like threads.
 
 <a name="PullRequestDiscussion"></a>
-## type [PullRequestDiscussion](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L70-L75>)
+## type [PullRequestDiscussion](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L71-L76>)
 
 PullRequestDiscussion contains comments, reviews, and review conversations for a pull request.
 
@@ -303,7 +305,7 @@ type PullRequestDiscussion struct {
 ```
 
 <a name="PullRequestIssueComment"></a>
-## type [PullRequestIssueComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L78-L87>)
+## type [PullRequestIssueComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L79-L88>)
 
 PullRequestIssueComment represents a top\-level pull request issue comment.
 
@@ -320,8 +322,19 @@ type PullRequestIssueComment struct {
 }
 ```
 
+<a name="PullRequestLoader"></a>
+## type [PullRequestLoader](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L238-L240>)
+
+PullRequestLoader loads complete pull request metadata by number.
+
+```go
+type PullRequestLoader interface {
+    GetPullRequest(prNumber int) (*PullRequest, error)
+}
+```
+
 <a name="PullRequestReview"></a>
-## type [PullRequestReview](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L90-L100>)
+## type [PullRequestReview](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L91-L101>)
 
 PullRequestReview represents a submitted pull request review.
 
@@ -340,7 +353,7 @@ type PullRequestReview struct {
 ```
 
 <a name="PullRequestReviewComment"></a>
-## type [PullRequestReviewComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L103-L131>)
+## type [PullRequestReviewComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L104-L132>)
 
 PullRequestReviewComment represents an inline pull request review comment.
 
@@ -392,7 +405,7 @@ type PullRequestStack struct {
 ```
 
 <a name="Release"></a>
-## type [Release](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L182-L188>)
+## type [Release](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L183-L189>)
 
 Release represents a GitHub release
 
@@ -407,7 +420,7 @@ type Release struct {
 ```
 
 <a name="Team"></a>
-## type [Team](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L154-L159>)
+## type [Team](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L155-L160>)
 
 Team represents a GitHub organization team.
 
@@ -421,7 +434,7 @@ type Team struct {
 ```
 
 <a name="Team.Canonical"></a>
-### func \(Team\) [Canonical](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L162>)
+### func \(Team\) [Canonical](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L163>)
 
 ```go
 func (t Team) Canonical() string
@@ -442,7 +455,7 @@ type UpdatePROptions struct {
 ```
 
 <a name="User"></a>
-## type [User](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L148-L151>)
+## type [User](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L149-L152>)
 
 User represents a GitHub user
 

--- a/internal/github/README.md
+++ b/internal/github/README.md
@@ -24,6 +24,7 @@ import "github.com/tagoro9/fotingo/internal/github"
   - [func NewWithOptions\(git git.Git, cfg \*viper.Viper, allowPrompt bool\) \(Github, error\)](<#NewWithOptions>)
 - [type GithubConfig](<#GithubConfig>)
 - [type Label](<#Label>)
+- [type NativeStackClient](<#NativeStackClient>)
 - [type PullRequest](<#PullRequest>)
 - [type PullRequestBodyUpdate](<#PullRequestBodyUpdate>)
 - [type PullRequestConversation](<#PullRequestConversation>)
@@ -32,6 +33,7 @@ import "github.com/tagoro9/fotingo/internal/github"
 - [type PullRequestIssueComment](<#PullRequestIssueComment>)
 - [type PullRequestReview](<#PullRequestReview>)
 - [type PullRequestReviewComment](<#PullRequestReviewComment>)
+- [type PullRequestStack](<#PullRequestStack>)
 - [type Release](<#Release>)
 - [type Team](<#Team>)
   - [func \(t Team\) Canonical\(\) string](<#Team.Canonical>)
@@ -54,7 +56,7 @@ var ErrOAuthClientIDMissing = errors.New("github oauth client id is missing in t
 ```
 
 <a name="FetchLatestReleaseTag"></a>
-## func [FetchLatestReleaseTag](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1255>)
+## func [FetchLatestReleaseTag](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1359>)
 
 ```go
 func FetchLatestReleaseTag(ctx context.Context, client *http.Client, owner string, repo string) (string, error)
@@ -78,7 +80,7 @@ type CreatePROptions struct {
 ```
 
 <a name="CreateReleaseOptions"></a>
-## type [CreateReleaseOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L163-L170>)
+## type [CreateReleaseOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L172-L179>)
 
 CreateReleaseOptions contains the options for creating a release
 
@@ -94,7 +96,7 @@ type CreateReleaseOptions struct {
 ```
 
 <a name="Github"></a>
-## type [Github](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L181-L218>)
+## type [Github](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L190-L227>)
 
 
 
@@ -140,7 +142,7 @@ type Github interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1608>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1712>)
 
 ```go
 func New(git git.Git, cfg *viper.Viper) (Github, error)
@@ -149,7 +151,7 @@ func New(git git.Git, cfg *viper.Viper) (Github, error)
 
 
 <a name="NewAuthOnly"></a>
-### func [NewAuthOnly](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1612>)
+### func [NewAuthOnly](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1716>)
 
 ```go
 func NewAuthOnly(cfg *viper.Viper) (Github, error)
@@ -158,7 +160,7 @@ func NewAuthOnly(cfg *viper.Viper) (Github, error)
 
 
 <a name="NewAuthOnlyWithOptions"></a>
-### func [NewAuthOnlyWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1616>)
+### func [NewAuthOnlyWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1720>)
 
 ```go
 func NewAuthOnlyWithOptions(cfg *viper.Viper, allowPrompt bool) (Github, error)
@@ -167,7 +169,7 @@ func NewAuthOnlyWithOptions(cfg *viper.Viper, allowPrompt bool) (Github, error)
 
 
 <a name="NewWithHTTPClient"></a>
-### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1555>)
+### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1659>)
 
 ```go
 func NewWithHTTPClient(g git.Git, cfg *viper.Viper, httpClient *http.Client, baseURL string) (Github, error)
@@ -176,7 +178,7 @@ func NewWithHTTPClient(g git.Git, cfg *viper.Viper, httpClient *http.Client, bas
 NewWithHTTPClient returns a new GitHub client using the provided HTTP client and base URL. This bypasses OAuth authentication and is intended for testing with mock servers.
 
 <a name="NewWithHTTPClientAndRepo"></a>
-### func [NewWithHTTPClientAndRepo](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1584>)
+### func [NewWithHTTPClientAndRepo](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1688>)
 
 ```go
 func NewWithHTTPClientAndRepo(g git.Git, cfg *viper.Viper, httpClient *http.Client, baseURL, owner, repo string) (Github, error)
@@ -185,7 +187,7 @@ func NewWithHTTPClientAndRepo(g git.Git, cfg *viper.Viper, httpClient *http.Clie
 NewWithHTTPClientAndRepo creates a GitHub client with explicit owner/repo, bypassing remote URL parsing.
 
 <a name="NewWithOptions"></a>
-### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1664>)
+### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L1768>)
 
 ```go
 func NewWithOptions(git git.Git, cfg *viper.Viper, allowPrompt bool) (Github, error)
@@ -194,7 +196,7 @@ func NewWithOptions(git git.Git, cfg *viper.Viper, allowPrompt bool) (Github, er
 
 
 <a name="GithubConfig"></a>
-## type [GithubConfig](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L231-L233>)
+## type [GithubConfig](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L247-L249>)
 
 
 
@@ -205,7 +207,7 @@ type GithubConfig struct {
 ```
 
 <a name="Label"></a>
-## type [Label](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L132-L136>)
+## type [Label](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L141-L145>)
 
 Label represents a GitHub label
 
@@ -217,8 +219,21 @@ type Label struct {
 }
 ```
 
+<a name="NativeStackClient"></a>
+## type [NativeStackClient](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L230-L234>)
+
+NativeStackClient is implemented by GitHub clients that support native PR stacks.
+
+```go
+type NativeStackClient interface {
+    ListPullRequestStacks(pullRequestNumber int) ([]PullRequestStack, error)
+    CreatePullRequestStack(pullRequestNumbers []int) (*PullRequestStack, error)
+    AddPullRequestsToStack(stackNumber int, pullRequestNumbers []int) (*PullRequestStack, error)
+}
+```
+
 <a name="PullRequest"></a>
-## type [PullRequest](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L45-L58>)
+## type [PullRequest](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L54-L67>)
 
 PullRequest represents a GitHub pull request
 
@@ -252,7 +267,7 @@ type PullRequestBodyUpdate struct {
 ```
 
 <a name="PullRequestConversation"></a>
-## type [PullRequestConversation](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L125-L129>)
+## type [PullRequestConversation](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L134-L138>)
 
 PullRequestConversation groups related inline review comments.
 
@@ -265,7 +280,7 @@ type PullRequestConversation struct {
 ```
 
 <a name="GroupPullRequestReviewComments"></a>
-### func [GroupPullRequestReviewComments](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L552>)
+### func [GroupPullRequestReviewComments](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L656>)
 
 ```go
 func GroupPullRequestReviewComments(comments []PullRequestReviewComment) []PullRequestConversation
@@ -274,7 +289,7 @@ func GroupPullRequestReviewComments(comments []PullRequestReviewComment) []PullR
 GroupPullRequestReviewComments groups inline review comments into conversation\-like threads.
 
 <a name="PullRequestDiscussion"></a>
-## type [PullRequestDiscussion](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L61-L66>)
+## type [PullRequestDiscussion](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L70-L75>)
 
 PullRequestDiscussion contains comments, reviews, and review conversations for a pull request.
 
@@ -288,7 +303,7 @@ type PullRequestDiscussion struct {
 ```
 
 <a name="PullRequestIssueComment"></a>
-## type [PullRequestIssueComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L69-L78>)
+## type [PullRequestIssueComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L78-L87>)
 
 PullRequestIssueComment represents a top\-level pull request issue comment.
 
@@ -306,7 +321,7 @@ type PullRequestIssueComment struct {
 ```
 
 <a name="PullRequestReview"></a>
-## type [PullRequestReview](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L81-L91>)
+## type [PullRequestReview](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L90-L100>)
 
 PullRequestReview represents a submitted pull request review.
 
@@ -325,7 +340,7 @@ type PullRequestReview struct {
 ```
 
 <a name="PullRequestReviewComment"></a>
-## type [PullRequestReviewComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L94-L122>)
+## type [PullRequestReviewComment](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L103-L131>)
 
 PullRequestReviewComment represents an inline pull request review comment.
 
@@ -361,8 +376,23 @@ type PullRequestReviewComment struct {
 }
 ```
 
+<a name="PullRequestStack"></a>
+## type [PullRequestStack](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L45-L51>)
+
+PullRequestStack contains GitHub\-native stack metadata and its ordered PRs.
+
+```go
+type PullRequestStack struct {
+    ID           int64
+    Number       int
+    BaseRef      string
+    Open         bool
+    PullRequests []PullRequest
+}
+```
+
 <a name="Release"></a>
-## type [Release](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L173-L179>)
+## type [Release](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L182-L188>)
 
 Release represents a GitHub release
 
@@ -377,7 +407,7 @@ type Release struct {
 ```
 
 <a name="Team"></a>
-## type [Team](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L145-L150>)
+## type [Team](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L154-L159>)
 
 Team represents a GitHub organization team.
 
@@ -391,7 +421,7 @@ type Team struct {
 ```
 
 <a name="Team.Canonical"></a>
-### func \(Team\) [Canonical](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L153>)
+### func \(Team\) [Canonical](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L162>)
 
 ```go
 func (t Team) Canonical() string
@@ -412,7 +442,7 @@ type UpdatePROptions struct {
 ```
 
 <a name="User"></a>
-## type [User](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L139-L142>)
+## type [User](<https://github.com/tagoro9/fotingo/blob/main/internal/github/github.go#L148-L151>)
 
 User represents a GitHub user
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -41,6 +41,15 @@ type PullRequestBodyUpdate struct {
 	Body   string
 }
 
+// PullRequestStack contains GitHub-native stack metadata and its ordered PRs.
+type PullRequestStack struct {
+	ID           int64
+	Number       int
+	BaseRef      string
+	Open         bool
+	PullRequests []PullRequest
+}
+
 // PullRequest represents a GitHub pull request
 type PullRequest struct {
 	Title     string
@@ -217,6 +226,13 @@ type Github interface {
 	CreateRelease(opts CreateReleaseOptions) (*Release, error)
 }
 
+// NativeStackClient is implemented by GitHub clients that support native PR stacks.
+type NativeStackClient interface {
+	ListPullRequestStacks(pullRequestNumber int) ([]PullRequestStack, error)
+	CreatePullRequestStack(pullRequestNumbers []int) (*PullRequestStack, error)
+	AddPullRequestsToStack(stackNumber int, pullRequestNumbers []int) (*PullRequestStack, error)
+}
+
 var oauthClientID = ""
 
 var ErrAuthRequired = errors.New("github authentication required; run `fotingo login` interactively")
@@ -364,6 +380,94 @@ func (g *github) UpdatePullRequestBodies(updates []PullRequestBodyUpdate) ([]*Pu
 		updated = append(updated, pr)
 	}
 	return updated, nil
+}
+
+type nativeStackPullRequest struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	HTMLURL string `json:"html_url"`
+	Body    string `json:"body"`
+	State   string `json:"state"`
+	Draft   bool   `json:"draft"`
+	Head    struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+type nativeStackResponse struct {
+	ID     int64 `json:"id"`
+	Number int   `json:"number"`
+	Open   bool  `json:"open"`
+	Base   struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+	PullRequests []nativeStackPullRequest `json:"pull_requests"`
+}
+
+func (g *github) nativeStackRequest(method, path string, body any, response any) error {
+	req, err := g.hub.NewRequest(method, path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+	_, err = g.hub.Do(context.Background(), req, response)
+	return err
+}
+
+func mapNativeStack(response nativeStackResponse) PullRequestStack {
+	stack := PullRequestStack{ID: response.ID, Number: response.Number, BaseRef: response.Base.Ref, Open: response.Open}
+	for _, item := range response.PullRequests {
+		stack.PullRequests = append(stack.PullRequests, PullRequest{Number: item.Number, Title: item.Title, HTMLURL: item.HTMLURL, Body: item.Body, State: item.State, Draft: item.Draft, HeadRef: item.Head.Ref, BaseRef: item.Base.Ref})
+	}
+	return stack
+}
+
+// ListPullRequestStacks lists native stacks, optionally filtered by PR number.
+func (g *github) ListPullRequestStacks(pullRequestNumber int) ([]PullRequestStack, error) {
+	var stacks []PullRequestStack
+	for page := 1; ; page++ {
+		path := fmt.Sprintf("repos/%s/%s/stacks?per_page=100&page=%d", g.owner, g.repo, page)
+		if pullRequestNumber > 0 {
+			path += fmt.Sprintf("&pull_request=%d", pullRequestNumber)
+		}
+		var response []nativeStackResponse
+		if err := g.nativeStackRequest(http.MethodGet, path, nil, &response); err != nil {
+			return nil, fmt.Errorf("failed to list pull request stacks: %w", err)
+		}
+		for _, item := range response {
+			stacks = append(stacks, mapNativeStack(item))
+		}
+		if len(response) < 100 {
+			break
+		}
+	}
+	return stacks, nil
+}
+
+// CreatePullRequestStack creates a native stack from bottom to top.
+func (g *github) CreatePullRequestStack(pullRequestNumbers []int) (*PullRequestStack, error) {
+	var response nativeStackResponse
+	if err := g.nativeStackRequest(http.MethodPost, fmt.Sprintf("repos/%s/%s/stacks", g.owner, g.repo), map[string]any{"pull_requests": pullRequestNumbers}, &response); err != nil {
+		return nil, fmt.Errorf("failed to create pull request stack: %w", err)
+	}
+	stack := mapNativeStack(response)
+	return &stack, nil
+}
+
+// AddPullRequestsToStack appends PRs to a native stack from the current top upward.
+func (g *github) AddPullRequestsToStack(stackNumber int, pullRequestNumbers []int) (*PullRequestStack, error) {
+	var response nativeStackResponse
+	path := fmt.Sprintf("repos/%s/%s/stacks/%d/add", g.owner, g.repo, stackNumber)
+	if err := g.nativeStackRequest(http.MethodPost, path, map[string]any{"pull_requests": pullRequestNumbers}, &response); err != nil {
+		return nil, fmt.Errorf("failed to add pull requests to stack #%d: %w", stackNumber, err)
+	}
+	stack := mapNativeStack(response)
+	return &stack, nil
 }
 
 // GetPullRequestDiscussion returns comments and reviews for an existing pull request.

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -59,6 +59,7 @@ type PullRequest struct {
 	URL       string
 	HTMLURL   string
 	HeadRef   string
+	HeadSHA   string
 	BaseRef   string
 	Draft     bool
 	State     string
@@ -233,6 +234,11 @@ type NativeStackClient interface {
 	AddPullRequestsToStack(stackNumber int, pullRequestNumbers []int) (*PullRequestStack, error)
 }
 
+// PullRequestLoader loads complete pull request metadata by number.
+type PullRequestLoader interface {
+	GetPullRequest(prNumber int) (*PullRequest, error)
+}
+
 var oauthClientID = ""
 
 var ErrAuthRequired = errors.New("github authentication required; run `fotingo login` interactively")
@@ -368,6 +374,15 @@ func (g *github) UpdatePullRequest(prNumber int, opts UpdatePROptions) (*PullReq
 	return mapPullRequest(pr), nil
 }
 
+// GetPullRequest loads a pull request by number.
+func (g *github) GetPullRequest(prNumber int) (*PullRequest, error) {
+	pr, _, err := g.hub.PullRequests.Get(context.Background(), g.owner, g.repo, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pull request #%d: %w", prNumber, err)
+	}
+	return mapPullRequest(pr), nil
+}
+
 // UpdatePullRequestBodies updates multiple pull request bodies in order.
 func (g *github) UpdatePullRequestBodies(updates []PullRequestBodyUpdate) ([]*PullRequest, error) {
 	updated := make([]*PullRequest, 0, len(updates))
@@ -440,7 +455,16 @@ func (g *github) ListPullRequestStacks(pullRequestNumber int) ([]PullRequestStac
 			return nil, fmt.Errorf("failed to list pull request stacks: %w", err)
 		}
 		for _, item := range response {
-			stacks = append(stacks, mapNativeStack(item))
+			stack := mapNativeStack(item)
+			loader := PullRequestLoader(g)
+			for index, member := range stack.PullRequests {
+				complete, err := loader.GetPullRequest(member.Number)
+				if err != nil {
+					return nil, fmt.Errorf("failed to enrich stack #%d pull request #%d: %w", stack.Number, member.Number, err)
+				}
+				stack.PullRequests[index] = *complete
+			}
+			stacks = append(stacks, stack)
 		}
 		if len(response) < 100 {
 			break
@@ -1618,6 +1642,7 @@ func mapPullRequest(pr *hub.PullRequest) *PullRequest {
 	}
 	if pr.Head != nil {
 		mapped.HeadRef = pr.Head.GetRef()
+		mapped.HeadSHA = pr.Head.GetSHA()
 	}
 	if pr.Base != nil {
 		mapped.BaseRef = pr.Base.GetRef()

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -173,7 +173,7 @@ Examples:
 		ReviewFlagDescription:              "Override the entire pull request body (use '-' for stdin)",
 		ReviewFlagTemplateSummary:          "Override the default Summary section content",
 		ReviewFlagTemplateDescription:      "Override the default Description section content; expands escaped \\n, \\r\\n, and \\t",
-		ReviewDefaultTemplate:              "**Summary**\n\n<!-- fotingo:start summary -->\n<!-- fotingo:end summary -->\n\n**Description**\n\n<!-- fotingo:start description -->\n<!-- fotingo:end description -->\n\n<!-- fotingo:start fixed-issues -->\n<!-- fotingo:end fixed-issues -->\n\n<!-- fotingo:start stacked-prs -->\n<!-- fotingo:end stacked-prs -->\n\n**Changes**\n\n<!-- fotingo:start changes -->\n<!-- fotingo:end changes -->\n\n{fotingo.banner}",
+		ReviewDefaultTemplate:              "**Summary**\n\n<!-- fotingo:start summary -->\n<!-- fotingo:end summary -->\n\n**Description**\n\n<!-- fotingo:start description -->\n<!-- fotingo:end description -->\n\n<!-- fotingo:start fixed-issues -->\n<!-- fotingo:end fixed-issues -->\n\n**Changes**\n\n<!-- fotingo:start changes -->\n<!-- fotingo:end changes -->\n\n{fotingo.banner}",
 		ReviewInitialCreating:              "Starting pull request creation...",
 		ReviewStatusInitGit:                "Initializing Git client...",
 		ReviewStatusGitInit:                "Git client initialized",

--- a/internal/jira/README.md
+++ b/internal/jira/README.md
@@ -39,7 +39,7 @@ var (
 ```
 
 <a name="IsUnauthorizedError"></a>
-## func [IsUnauthorizedError](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L572>)
+## func [IsUnauthorizedError](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L574>)
 
 ```go
 func IsUnauthorizedError(err error) bool
@@ -48,7 +48,7 @@ func IsUnauthorizedError(err error) bool
 IsUnauthorizedError returns true when the Jira API error corresponds to HTTP 401.
 
 <a name="NormalizeRootURL"></a>
-## func [NormalizeRootURL](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1536>)
+## func [NormalizeRootURL](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1570>)
 
 ```go
 func NormalizeRootURL(raw string, allowHTTP bool) (string, error)
@@ -57,7 +57,7 @@ func NormalizeRootURL(raw string, allowHTTP bool) (string, error)
 NormalizeRootURL validates and normalizes a Jira site root URL or Atlassian Cloud Jira API root URL.
 
 <a name="ShouldWarnIgnoredStoredOAuthToken"></a>
-## func [ShouldWarnIgnoredStoredOAuthToken](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L564>)
+## func [ShouldWarnIgnoredStoredOAuthToken](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L566>)
 
 ```go
 func ShouldWarnIgnoredStoredOAuthToken(cfg *viper.Viper) bool
@@ -164,7 +164,7 @@ type Jira interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1349>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1383>)
 
 ```go
 func New(cfg *viper.Viper) (Jira, error)
@@ -173,7 +173,7 @@ func New(cfg *viper.Viper) (Jira, error)
 New returns a new instance of an authenticated Jira client
 
 <a name="NewWithHTTPClient"></a>
-### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1318>)
+### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1352>)
 
 ```go
 func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string) (Jira, error)
@@ -182,7 +182,7 @@ func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string
 NewWithHTTPClient returns a new Jira client using the provided HTTP client and base URL. This bypasses OAuth authentication and is intended for testing with mock servers.
 
 <a name="NewWithOptions"></a>
-### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1354>)
+### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1388>)
 
 ```go
 func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
@@ -191,7 +191,7 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
 NewWithOptions returns an authenticated Jira client with prompt behavior controls.
 
 <a name="TransitionMapping"></a>
-## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L647-L651>)
+## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L681-L685>)
 
 TransitionMapping maps IssueStatus to regex patterns that should match transition names
 

--- a/internal/jira/README.md
+++ b/internal/jira/README.md
@@ -39,7 +39,7 @@ var (
 ```
 
 <a name="IsUnauthorizedError"></a>
-## func [IsUnauthorizedError](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L574>)
+## func [IsUnauthorizedError](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L573>)
 
 ```go
 func IsUnauthorizedError(err error) bool
@@ -48,7 +48,7 @@ func IsUnauthorizedError(err error) bool
 IsUnauthorizedError returns true when the Jira API error corresponds to HTTP 401.
 
 <a name="NormalizeRootURL"></a>
-## func [NormalizeRootURL](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1570>)
+## func [NormalizeRootURL](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1572>)
 
 ```go
 func NormalizeRootURL(raw string, allowHTTP bool) (string, error)
@@ -57,7 +57,7 @@ func NormalizeRootURL(raw string, allowHTTP bool) (string, error)
 NormalizeRootURL validates and normalizes a Jira site root URL or Atlassian Cloud Jira API root URL.
 
 <a name="ShouldWarnIgnoredStoredOAuthToken"></a>
-## func [ShouldWarnIgnoredStoredOAuthToken](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L566>)
+## func [ShouldWarnIgnoredStoredOAuthToken](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L565>)
 
 ```go
 func ShouldWarnIgnoredStoredOAuthToken(cfg *viper.Viper) bool
@@ -164,7 +164,7 @@ type Jira interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1383>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1380>)
 
 ```go
 func New(cfg *viper.Viper) (Jira, error)
@@ -173,7 +173,7 @@ func New(cfg *viper.Viper) (Jira, error)
 New returns a new instance of an authenticated Jira client
 
 <a name="NewWithHTTPClient"></a>
-### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1352>)
+### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1348>)
 
 ```go
 func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string) (Jira, error)
@@ -182,7 +182,7 @@ func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string
 NewWithHTTPClient returns a new Jira client using the provided HTTP client and base URL. This bypasses OAuth authentication and is intended for testing with mock servers.
 
 <a name="NewWithOptions"></a>
-### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1388>)
+### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1385>)
 
 ```go
 func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
@@ -191,7 +191,7 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
 NewWithOptions returns an authenticated Jira client with prompt behavior controls.
 
 <a name="TransitionMapping"></a>
-## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L681-L685>)
+## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L677-L681>)
 
 TransitionMapping maps IssueStatus to regex patterns that should match transition names
 

--- a/internal/jira/README.md
+++ b/internal/jira/README.md
@@ -48,7 +48,7 @@ func IsUnauthorizedError(err error) bool
 IsUnauthorizedError returns true when the Jira API error corresponds to HTTP 401.
 
 <a name="NormalizeRootURL"></a>
-## func [NormalizeRootURL](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1572>)
+## func [NormalizeRootURL](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1574>)
 
 ```go
 func NormalizeRootURL(raw string, allowHTTP bool) (string, error)
@@ -164,7 +164,7 @@ type Jira interface {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1380>)
+### func [New](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1386>)
 
 ```go
 func New(cfg *viper.Viper) (Jira, error)
@@ -173,7 +173,7 @@ func New(cfg *viper.Viper) (Jira, error)
 New returns a new instance of an authenticated Jira client
 
 <a name="NewWithHTTPClient"></a>
-### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1348>)
+### func [NewWithHTTPClient](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1354>)
 
 ```go
 func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string) (Jira, error)
@@ -182,7 +182,7 @@ func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string
 NewWithHTTPClient returns a new Jira client using the provided HTTP client and base URL. This bypasses OAuth authentication and is intended for testing with mock servers.
 
 <a name="NewWithOptions"></a>
-### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1385>)
+### func [NewWithOptions](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L1391>)
 
 ```go
 func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
@@ -191,7 +191,7 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error)
 NewWithOptions returns an authenticated Jira client with prompt behavior controls.
 
 <a name="TransitionMapping"></a>
-## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L677-L681>)
+## type [TransitionMapping](<https://github.com/tagoro9/fotingo/blob/main/internal/jira/client.go#L683-L687>)
 
 TransitionMapping maps IssueStatus to regex patterns that should match transition names
 

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -292,6 +292,8 @@ type jira struct {
 	*config.ViperConfigurableService
 	client           *jiraClient.Client
 	jiraRootURL      string
+	jiraDisplayURL   string
+	displayURLLoaded bool
 	allowPrompt      bool
 	promptRoot       func() (string, error)
 	promptAuthMethod func() (string, error)
@@ -591,9 +593,41 @@ func (j *jira) GetIssueURL(issueId string) string {
 		return ""
 	}
 	if isAtlassianCloudJiraAPIURL(rootURL) {
-		return ""
+		if !j.displayURLLoaded {
+			j.loadJiraDisplayURL()
+		}
+		if j.jiraDisplayURL == "" {
+			return ""
+		}
+		rootURL = j.jiraDisplayURL
 	}
 	return fmt.Sprintf("%s/browse/%s", rootURL, strings.ToUpper(issueId))
+}
+
+type jiraServerInfo struct {
+	DisplayURL string `json:"displayUrl"`
+}
+
+func (j *jira) loadJiraDisplayURL() {
+	j.displayURLLoaded = true
+	if j.client == nil {
+		return
+	}
+
+	request, err := j.client.NewRequest(http.MethodGet, "rest/api/3/serverInfo", nil)
+	if err != nil {
+		return
+	}
+
+	var serverInfo jiraServerInfo
+	if _, err := j.client.Do(request, &serverInfo); err != nil {
+		return
+	}
+
+	displayURL, err := NormalizeRootURL(serverInfo.DisplayURL, false)
+	if err == nil {
+		j.jiraDisplayURL = displayURL
+	}
 }
 
 // GetIssueUrl returns the URL of the issue given its id.

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -593,6 +593,12 @@ func (j *jira) GetIssueURL(issueId string) string {
 	}
 	if isAtlassianCloudJiraAPIURL(rootURL) {
 		if j.jiraDisplayURL == "" {
+			// Resolve this lazily so constructing a Jira client never performs an
+			// extra request. loadJiraDisplayURL persists the result for future
+			// clients; this is only needed once for a new Cloud API root.
+			j.loadJiraDisplayURL()
+		}
+		if j.jiraDisplayURL == "" {
 			return ""
 		}
 		rootURL = j.jiraDisplayURL
@@ -1410,10 +1416,6 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error) {
 	_, err := j.Authenticate()
 	if err != nil {
 		return nil, err
-	}
-	rootURL, err := j.resolveJiraRootURL()
-	if err == nil && isAtlassianCloudJiraAPIURL(rootURL) && j.jiraDisplayURL == "" {
-		j.loadJiraDisplayURL()
 	}
 	return j, nil
 }

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -293,7 +293,6 @@ type jira struct {
 	client           *jiraClient.Client
 	jiraRootURL      string
 	jiraDisplayURL   string
-	displayURLLoaded bool
 	allowPrompt      bool
 	promptRoot       func() (string, error)
 	promptAuthMethod func() (string, error)
@@ -593,9 +592,6 @@ func (j *jira) GetIssueURL(issueId string) string {
 		return ""
 	}
 	if isAtlassianCloudJiraAPIURL(rootURL) {
-		if !j.displayURLLoaded {
-			j.loadJiraDisplayURL()
-		}
 		if j.jiraDisplayURL == "" {
 			return ""
 		}
@@ -609,7 +605,6 @@ type jiraServerInfo struct {
 }
 
 func (j *jira) loadJiraDisplayURL() {
-	j.displayURLLoaded = true
 	if j.client == nil {
 		return
 	}
@@ -627,6 +622,7 @@ func (j *jira) loadJiraDisplayURL() {
 	displayURL, err := NormalizeRootURL(serverInfo.DisplayURL, false)
 	if err == nil {
 		j.jiraDisplayURL = displayURL
+		_ = j.SaveConfig("displayUrl", displayURL)
 	}
 }
 
@@ -1362,6 +1358,7 @@ func NewWithHTTPClient(cfg *viper.Viper, httpClient *http.Client, baseURL string
 		ViperConfigurableService: configurableService,
 		client:                   client,
 		allowPrompt:              false,
+		jiraDisplayURL:           strings.TrimSpace(configurableService.GetConfigString("displayUrl")),
 		metadataCache:            metadataCache,
 		cacheInitErr:             cacheErr,
 	}
@@ -1392,6 +1389,7 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error) {
 	j := &jira{
 		ViperConfigurableService: configurableService,
 		allowPrompt:              allowPrompt,
+		jiraDisplayURL:           strings.TrimSpace(configurableService.GetConfigString("displayUrl")),
 		promptRoot:               promptForJiraRootURL,
 		promptAuthMethod:         promptJiraAuthMethod,
 		promptAPICreds:           promptJiraAPICredentials,
@@ -1412,6 +1410,10 @@ func NewWithOptions(cfg *viper.Viper, allowPrompt bool) (Jira, error) {
 	_, err := j.Authenticate()
 	if err != nil {
 		return nil, err
+	}
+	rootURL, err := j.resolveJiraRootURL()
+	if err == nil && isAtlassianCloudJiraAPIURL(rootURL) && j.jiraDisplayURL == "" {
+		j.loadJiraDisplayURL()
 	}
 	return j, nil
 }

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -1483,21 +1483,30 @@ func TestResolveJiraRootURL_NonInteractiveMissingConfig(t *testing.T) {
 }
 
 func TestGetIssueURL_AtlassianCloudAPIURLUsesDisplayURL(t *testing.T) {
+	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		assert.Equal(t, "/rest/api/3/serverInfo", r.URL.Path)
 		assert.Equal(t, http.MethodGet, r.Method)
 		_, _ = w.Write([]byte(`{"displayUrl":"https://acme.atlassian.net/"}`))
 	}))
 	defer server.Close()
 
-	jiraClient, err := NewWithHTTPClient(viper.New(), server.Client(), server.URL)
+	cfg := viper.New()
+	cfg.SetConfigFile(filepath.Join(t.TempDir(), "config.yaml"))
+	cfg.Set("jira.root", "https://api.atlassian.com/ex/jira/cloud-123")
+	jiraClient, err := NewWithHTTPClient(cfg, server.Client(), server.URL)
 	require.NoError(t, err)
 	j := jiraClient.(*jira)
-	j.jiraRootURL = "https://api.atlassian.com/ex/jira/cloud-123"
+	j.loadJiraDisplayURL()
 
 	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-123", j.GetIssueURL("test-123"))
-	assert.True(t, j.displayURLLoaded)
-	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-456", j.GetIssueURL("TEST-456"))
+	assert.Equal(t, "https://acme.atlassian.net", cfg.GetString("jira.displayUrl"))
+
+	secondClient, err := NewWithHTTPClient(cfg, server.Client(), server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-456", secondClient.GetIssueURL("TEST-456"))
+	assert.Equal(t, 1, requestCount)
 }
 
 func TestNormalizeJiraRootURL(t *testing.T) {

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -1502,7 +1502,14 @@ func TestGetIssueURL_AtlassianCloudAPIURLUsesDisplayURL(t *testing.T) {
 	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-123", j.GetIssueURL("test-123"))
 	assert.Equal(t, "https://acme.atlassian.net", cfg.GetString("jira.displayUrl"))
 
-	secondClient, err := NewWithHTTPClient(cfg, server.Client(), server.URL)
+	reloadedCfg := viper.New()
+	reloadedCfg.SetConfigFile(cfg.ConfigFileUsed())
+	reloadedCfg.SetConfigType("yaml")
+	require.NoError(t, reloadedCfg.ReadInConfig())
+	reloadedCfg.Set("jira.root", "https://api.atlassian.com/ex/jira/cloud-123")
+	assert.Equal(t, "https://acme.atlassian.net", reloadedCfg.GetString("jira.displayUrl"))
+
+	secondClient, err := NewWithHTTPClient(reloadedCfg, server.Client(), server.URL)
 	require.NoError(t, err)
 	assert.Equal(t, 1, requestCount, "a cached display URL should avoid another serverInfo request")
 	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-456", secondClient.GetIssueURL("TEST-456"))

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -1482,16 +1482,22 @@ func TestResolveJiraRootURL_NonInteractiveMissingConfig(t *testing.T) {
 	assert.ErrorIs(t, err, errMissingJiraRoot)
 }
 
-func TestGetIssueURL_AtlassianCloudAPIURLReturnsEmpty(t *testing.T) {
-	cfg := viper.New()
-	cfg.Set("jira.root", "https://api.atlassian.com/ex/jira/cloud-123")
+func TestGetIssueURL_AtlassianCloudAPIURLUsesDisplayURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/serverInfo", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		_, _ = w.Write([]byte(`{"displayUrl":"https://acme.atlassian.net/"}`))
+	}))
+	defer server.Close()
 
-	j := &jira{
-		ViperConfigurableService: &config.ViperConfigurableService{Config: cfg, Prefix: "jira"},
-		allowPrompt:              false,
-	}
+	jiraClient, err := NewWithHTTPClient(viper.New(), server.Client(), server.URL)
+	require.NoError(t, err)
+	j := jiraClient.(*jira)
+	j.jiraRootURL = "https://api.atlassian.com/ex/jira/cloud-123"
 
-	assert.Equal(t, "", j.GetIssueURL("TEST-123"))
+	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-123", j.GetIssueURL("test-123"))
+	assert.True(t, j.displayURLLoaded)
+	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-456", j.GetIssueURL("TEST-456"))
 }
 
 func TestNormalizeJiraRootURL(t *testing.T) {

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -1498,15 +1498,32 @@ func TestGetIssueURL_AtlassianCloudAPIURLUsesDisplayURL(t *testing.T) {
 	jiraClient, err := NewWithHTTPClient(cfg, server.Client(), server.URL)
 	require.NoError(t, err)
 	j := jiraClient.(*jira)
-	j.loadJiraDisplayURL()
 
 	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-123", j.GetIssueURL("test-123"))
 	assert.Equal(t, "https://acme.atlassian.net", cfg.GetString("jira.displayUrl"))
 
 	secondClient, err := NewWithHTTPClient(cfg, server.Client(), server.URL)
 	require.NoError(t, err)
+	assert.Equal(t, 1, requestCount, "a cached display URL should avoid another serverInfo request")
 	assert.Equal(t, "https://acme.atlassian.net/browse/TEST-456", secondClient.GetIssueURL("TEST-456"))
 	assert.Equal(t, 1, requestCount)
+}
+
+func TestNewWithHTTPClient_DoesNotResolveCloudDisplayURL(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+	}))
+	defer server.Close()
+
+	cfg := viper.New()
+	cfg.SetConfigFile(filepath.Join(t.TempDir(), "config.yaml"))
+	cfg.Set("jira.root", "https://api.atlassian.com/ex/jira/cloud-123")
+
+	_, err := NewWithHTTPClient(cfg, server.Client(), server.URL)
+
+	require.NoError(t, err)
+	assert.Zero(t, requestCount)
 }
 
 func TestNormalizeJiraRootURL(t *testing.T) {

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -748,7 +748,7 @@ func TestDefaultPRTemplate_ContainsRequiredSections(t *testing.T) {
 	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:start summary -->")
 	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:start description -->")
 	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:start fixed-issues -->")
-	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:start stacked-prs -->")
+	assert.NotContains(t, defaultPRTemplate, "stacked-prs")
 	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:start changes -->")
 	assert.NotContains(t, defaultPRTemplate, "{summary}")
 	assert.NotContains(t, defaultPRTemplate, "{description}")

--- a/pkg/commands/review_stacks.go
+++ b/pkg/commands/review_stacks.go
@@ -92,8 +92,8 @@ var reviewStacksCmd = &cobra.Command{
 
 var reviewStacksSyncCmd = &cobra.Command{
 	Use:   "sync",
-	Short: "Refresh stacked PR sections across the current stack",
-	Long:  "Refresh the deterministic stacked PR sections for every open pull request in the current stack.",
+	Short: "Refresh native stack state",
+	Long:  "Refresh and display the native GitHub pull request stack without editing PR bodies.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stack, err := syncCurrentReviewStack()
 		if ShouldOutputJSON() {
@@ -104,9 +104,7 @@ var reviewStacksSyncCmd = &cobra.Command{
 		}
 		if !ShouldOutputJSON() {
 			return runWithSharedShell(func(out commandruntime.LocalizedEmitter) error {
-				for _, member := range stack.Members {
-					out.InfoRaw(commandruntime.LogEmojiCheck, fmt.Sprintf("Updated pull request #%d: %s", member.Number, member.URL))
-				}
+				out.InfoRaw(commandruntime.LogEmojiCheck, "Native pull request stack refreshed; PR bodies were not changed")
 				return nil
 			})
 		}
@@ -162,23 +160,6 @@ func syncCurrentReviewStack() (*reviewStackContext, error) {
 	}
 	stack, err := discoverCurrentReviewStack(gitClient, ghClient)
 	if err != nil {
-		return nil, err
-	}
-	updates := make([]github.PullRequestBodyUpdate, 0, len(stack.rawMembers))
-	for _, member := range stack.rawMembers {
-		body, err := internalreview.ReplaceStackedPRSectionContent(
-			member.Body,
-			internalreview.RenderStackedPRSection(internalreview.StackRenderOptions{
-				StackID: stack.StackID,
-				Items:   stackItemsForMembers(stack.rawMembers, member.Number),
-			}),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("pull request #%d: %w", member.Number, err)
-		}
-		updates = append(updates, github.PullRequestBodyUpdate{Number: member.Number, Body: body})
-	}
-	if _, err := ghClient.UpdatePullRequestBodies(updates); err != nil {
 		return nil, err
 	}
 	return stack, nil
@@ -264,33 +245,23 @@ func discoverCurrentReviewStack(gitClient git.Git, ghClient reviewStacksGithub) 
 		return nil, fmt.Errorf("no pull request found for branch %s", currentBranch)
 	}
 
-	stackID := internalreview.ExtractStackID(currentPR.Body)
-	members := []github.PullRequest{*currentPR}
-	if stackID != "" {
-		stackMembers, err := ghClient.ListOpenPullRequestsByStackID(stackID)
-		if err != nil {
-			return nil, err
-		}
-		members = stackMembers
-		members = appendReviewStackMember(members, *currentPR)
-	} else {
-		children, err := ghClient.ListOpenPullRequestsByBaseBranch(currentPR.HeadRef)
-		if err != nil {
-			return nil, err
-		}
-		if len(children) == 0 {
-			return nil, fmt.Errorf("no stacked pull requests found for branch %s", currentBranch)
-		}
-		stackID = internalreview.StackIDForRootPR(currentPR.Number, currentPR.HTMLURL)
-		for _, child := range children {
-			members = appendReviewStackMember(members, child)
-		}
+	nativeStackClient, ok := ghClient.(github.NativeStackClient)
+	if !ok {
+		return nil, fmt.Errorf("github client does not support native pull request stacks")
 	}
-	ordered, err := internalreview.OrderStackPullRequests(members)
+	stacks, err := nativeStackClient.ListPullRequestStacks(currentPR.Number)
 	if err != nil {
 		return nil, err
 	}
-	return buildReviewStackContext(stackID, currentBranch, currentPR.Number, ordered), nil
+	if len(stacks) == 0 {
+		return nil, fmt.Errorf("no native pull request stack found for branch %s", currentBranch)
+	}
+	if len(stacks) > 1 {
+		return nil, fmt.Errorf("pull request #%d belongs to %d native stacks", currentPR.Number, len(stacks))
+	}
+	stack := stacks[0]
+	members := append([]github.PullRequest(nil), stack.PullRequests...)
+	return buildReviewStackContext(strconv.Itoa(stack.Number), currentBranch, currentPR.Number, members), nil
 }
 
 func buildReviewStackContext(stackID string, currentBranch string, currentPRNumber int, members []github.PullRequest) *reviewStackContext {
@@ -415,25 +386,6 @@ func formatReviewStackPR(member reviewStackMember) string {
 	return lipgloss.NewStyle().Hyperlink(url).Render(label)
 }
 
-func stackItemsForMembers(members []github.PullRequest, currentNumber int) []internalreview.StackPullRequest {
-	items := make([]internalreview.StackPullRequest, 0, len(members))
-	for _, member := range members {
-		jiraKey := internalreview.DeriveStackJiraKey(member.HeadRef, member.Title, member.Body)
-		items = append(items, internalreview.StackPullRequest{
-			Number:  member.Number,
-			Title:   member.Title,
-			HTMLURL: member.HTMLURL,
-			JiraKey: jiraKey,
-			JiraURL: reviewStackJiraURL(jiraKey),
-			State:   member.State,
-			Draft:   member.Draft,
-			Merged:  member.Merged,
-			Current: member.Number == currentNumber,
-		})
-	}
-	return items
-}
-
 func reviewStackJiraURL(jiraKey string) string {
 	key := strings.TrimSpace(jiraKey)
 	if key == "" {
@@ -444,15 +396,6 @@ func reviewStackJiraURL(jiraKey string) string {
 		return ""
 	}
 	return fmt.Sprintf("%s/browse/%s", root, strings.ToUpper(key))
-}
-
-func appendReviewStackMember(members []github.PullRequest, pr github.PullRequest) []github.PullRequest {
-	for _, member := range members {
-		if member.Number == pr.Number {
-			return members
-		}
-	}
-	return append(members, pr)
 }
 
 func loadStackWorktrees(gitClient reviewStacksGit) (map[string]git.WorktreeInfo, error) {

--- a/pkg/commands/review_stacks.go
+++ b/pkg/commands/review_stacks.go
@@ -37,6 +37,7 @@ type reviewStacksGit interface {
 
 type reviewStackContext struct {
 	StackID       string               `json:"stackId"`
+	BaseRef       string               `json:"baseRef"`
 	CurrentBranch string               `json:"currentBranch"`
 	CurrentPR     int                  `json:"currentPullRequest"`
 	Members       []reviewStackMember  `json:"members"`
@@ -174,15 +175,19 @@ func rebaseCurrentReviewStack(push bool) (*reviewStackContext, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(stack.rawMembers) < 2 {
-		return stack, fmt.Errorf("stack must contain at least two pull requests to rebase")
+	if len(stack.rawMembers) == 0 {
+		return stack, fmt.Errorf("native pull request stack contains no pull requests to rebase")
 	}
 
 	worktreeByBranch, err := loadStackWorktrees(gitClient)
 	if err != nil {
 		return stack, err
 	}
-	for _, member := range stack.rawMembers[1:] {
+	firstMember := 1
+	if len(stack.rawMembers) == 1 {
+		firstMember = 0
+	}
+	for _, member := range stack.rawMembers[firstMember:] {
 		worktree, ok := worktreeByBranch[member.HeadRef]
 		if !ok {
 			return stack, fmt.Errorf("no local worktree found for stack branch %s", member.HeadRef)
@@ -194,6 +199,19 @@ func rebaseCurrentReviewStack(push bool) (*reviewStackContext, error) {
 		if !clean {
 			return stack, fmt.Errorf("worktree %s for branch %s has uncommitted changes", worktree.Path, member.HeadRef)
 		}
+	}
+	if len(stack.rawMembers) == 1 {
+		member := stack.rawMembers[0]
+		worktree := worktreeByBranch[member.HeadRef]
+		if err := gitClient.RebaseWorktree(worktree.Path, stack.BaseRef); err != nil {
+			return stack, fmt.Errorf("failed to rebase branch %s in worktree %s: %w", member.HeadRef, worktree.Path, err)
+		}
+		if push {
+			if err := gitClient.PushWorktreeBranch(worktree.Path, member.HeadRef, true); err != nil {
+				return stack, fmt.Errorf("failed to push branch %s from worktree %s: %w", member.HeadRef, worktree.Path, err)
+			}
+		}
+		return stack, nil
 	}
 	for index := 1; index < len(stack.rawMembers); index++ {
 		member := stack.rawMembers[index]
@@ -261,12 +279,13 @@ func discoverCurrentReviewStack(gitClient git.Git, ghClient reviewStacksGithub) 
 	}
 	stack := stacks[0]
 	members := append([]github.PullRequest(nil), stack.PullRequests...)
-	return buildReviewStackContext(strconv.Itoa(stack.Number), currentBranch, currentPR.Number, members), nil
+	return buildReviewStackContext(strconv.Itoa(stack.Number), stack.BaseRef, currentBranch, currentPR.Number, members), nil
 }
 
-func buildReviewStackContext(stackID string, currentBranch string, currentPRNumber int, members []github.PullRequest) *reviewStackContext {
+func buildReviewStackContext(stackID string, baseRef string, currentBranch string, currentPRNumber int, members []github.PullRequest) *reviewStackContext {
 	stack := &reviewStackContext{
 		StackID:       stackID,
+		BaseRef:       baseRef,
 		CurrentBranch: currentBranch,
 		CurrentPR:     currentPRNumber,
 		Members:       make([]reviewStackMember, 0, len(members)),

--- a/pkg/commands/review_stacks_test.go
+++ b/pkg/commands/review_stacks_test.go
@@ -63,11 +63,31 @@ type reviewStacksMockGitHub struct {
 	headPRs       map[string]*github.PullRequest
 	basePRs       map[string][]github.PullRequest
 	stackMembers  map[string][]github.PullRequest
+	nativeStacks  []github.PullRequestStack
 	bodyUpdates   []github.PullRequestBodyUpdate
 	findErr       error
 	baseErr       error
 	stackErr      error
 	bodyUpdateErr error
+}
+
+func (m *reviewStacksMockGitHub) ListPullRequestStacks(int) ([]github.PullRequestStack, error) {
+	if len(m.nativeStacks) == 0 {
+		for id, members := range m.stackMembers {
+			stack := github.PullRequestStack{Number: 42, PullRequests: append([]github.PullRequest(nil), members...)}
+			if id == "owner/repo#12" {
+				stack.Number = 12
+			}
+			return []github.PullRequestStack{stack}, nil
+		}
+	}
+	return append([]github.PullRequestStack(nil), m.nativeStacks...), nil
+}
+func (m *reviewStacksMockGitHub) CreatePullRequestStack([]int) (*github.PullRequestStack, error) {
+	return nil, nil
+}
+func (m *reviewStacksMockGitHub) AddPullRequestsToStack(int, []int) (*github.PullRequestStack, error) {
+	return nil, nil
 }
 
 func (m *reviewStacksMockGitHub) FindOpenPullRequestByHeadBranch(branch string) (*github.PullRequest, bool, error) {
@@ -125,7 +145,7 @@ func TestDiscoverCurrentReviewStack_UsesExistingStackID(t *testing.T) {
 	stack, err := discoverCurrentReviewStack(gitClient, ghClient)
 
 	require.NoError(t, err)
-	assert.Equal(t, "owner/repo#12", stack.StackID)
+	assert.Equal(t, "12", stack.StackID)
 	require.Len(t, stack.Members, 2)
 	assert.Equal(t, 12, stack.Members[0].Number)
 	assert.Equal(t, 13, stack.Members[1].Number)
@@ -133,7 +153,7 @@ func TestDiscoverCurrentReviewStack_UsesExistingStackID(t *testing.T) {
 	assert.Equal(t, "🟢", stack.Members[1].Status)
 }
 
-func TestDiscoverCurrentReviewStack_DiscoversChildWhenRootHasNoStackID(t *testing.T) {
+func TestDiscoverCurrentReviewStack_RejectsMarkerOnlyStack(t *testing.T) {
 	parent, child, _ := reviewStackPullRequests()
 	parent.Body = emptyStackBody()
 	ghClient := &reviewStacksMockGitHub{
@@ -145,10 +165,9 @@ func TestDiscoverCurrentReviewStack_DiscoversChildWhenRootHasNoStackID(t *testin
 
 	stack, err := discoverCurrentReviewStack(gitClient, ghClient)
 
-	require.NoError(t, err)
-	assert.Equal(t, "owner/repo#12", stack.StackID)
-	require.Len(t, stack.Members, 2)
-	assert.True(t, stack.Members[0].Current)
+	require.Error(t, err)
+	assert.Nil(t, stack)
+	assert.Contains(t, err.Error(), "no native pull request stack found")
 }
 
 func TestDiscoverCurrentReviewStack_RejectsStandalonePullRequest(t *testing.T) {
@@ -165,7 +184,7 @@ func TestDiscoverCurrentReviewStack_RejectsStandalonePullRequest(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, stack)
-	assert.Contains(t, err.Error(), "no stacked pull requests found")
+	assert.Contains(t, err.Error(), "no native pull request stack found")
 }
 
 func TestSyncCurrentReviewStack_UpdatesEveryStackMember(t *testing.T) {
@@ -186,14 +205,8 @@ func TestSyncCurrentReviewStack_UpdatesEveryStackMember(t *testing.T) {
 	stack, err := syncCurrentReviewStack()
 
 	require.NoError(t, err)
-	assert.Equal(t, "owner/repo#12", stack.StackID)
-	require.Len(t, ghClient.bodyUpdates, 2)
-	assert.Equal(t, 12, ghClient.bodyUpdates[0].Number)
-	assert.Equal(t, 13, ghClient.bodyUpdates[1].Number)
-	assert.Contains(t, ghClient.bodyUpdates[0].Body, "**Stacked PRs**")
-	assert.Contains(t, ghClient.bodyUpdates[0].Body, "| 1 👉 | [ABC-1](https://jira.example.com/browse/ABC-1) | [#12")
-	assert.Contains(t, ghClient.bodyUpdates[1].Body, "| 2 👉 | [ABC-2](https://jira.example.com/browse/ABC-2) | [#13")
-	assert.NotContains(t, ghClient.bodyUpdates[1].Body, "| Status |")
+	assert.Equal(t, "12", stack.StackID)
+	assert.Empty(t, ghClient.bodyUpdates)
 }
 
 func TestSyncCurrentReviewStack_FailsBeforePartialUpdateWhenMarkerMissing(t *testing.T) {
@@ -210,10 +223,9 @@ func TestSyncCurrentReviewStack_FailsBeforePartialUpdateWhenMarkerMissing(t *tes
 
 	stack, err := syncCurrentReviewStack()
 
-	require.Error(t, err)
-	assert.Nil(t, stack)
+	require.NoError(t, err)
+	assert.NotNil(t, stack)
 	assert.Empty(t, ghClient.bodyUpdates)
-	assert.Contains(t, err.Error(), "pull request #12")
 }
 
 func TestRebaseCurrentReviewStack_UsesBranchWorktreesInOrder(t *testing.T) {
@@ -234,7 +246,7 @@ func TestRebaseCurrentReviewStack_UsesBranchWorktreesInOrder(t *testing.T) {
 	ghClient := &reviewStacksMockGitHub{
 		mockGitHub:   &mockGitHub{},
 		headPRs:      map[string]*github.PullRequest{child.HeadRef: &child},
-		stackMembers: map[string][]github.PullRequest{"owner/repo#12": {leaf, parent, child}},
+		stackMembers: map[string][]github.PullRequest{"owner/repo#12": {parent, child, leaf}},
 	}
 	restoreClients(gitClient, ghClient)
 

--- a/pkg/commands/review_stacks_test.go
+++ b/pkg/commands/review_stacks_test.go
@@ -264,6 +264,37 @@ func TestRebaseCurrentReviewStack_UsesBranchWorktreesInOrder(t *testing.T) {
 	}, gitClient.pushes)
 }
 
+func TestRebaseCurrentReviewStack_RebasesRemainingPRAfterParentMerge(t *testing.T) {
+	restoreClients := stubReviewStacksClients(t)
+	parent, child, _ := reviewStackPullRequests()
+	parent.Merged = true
+	parent.State = "closed"
+	gitClient := &reviewStacksMockGit{
+		mockGit: &mockGit{currentBranch: child.HeadRef},
+		worktrees: []git.WorktreeInfo{
+			{Path: "/workspace/child", Branch: child.HeadRef},
+		},
+		clean: map[string]bool{"/workspace/child": true},
+	}
+	ghClient := &reviewStacksMockGitHub{
+		mockGitHub: &mockGitHub{},
+		headPRs:    map[string]*github.PullRequest{child.HeadRef: &child},
+		nativeStacks: []github.PullRequestStack{{
+			Number:       12,
+			BaseRef:      "main",
+			PullRequests: []github.PullRequest{child},
+		}},
+	}
+	restoreClients(gitClient, ghClient)
+
+	stack, err := rebaseCurrentReviewStack(true)
+
+	require.NoError(t, err)
+	assert.Equal(t, "main", stack.BaseRef)
+	assert.Equal(t, []reviewStacksRebaseCall{{path: "/workspace/child", base: "main"}}, gitClient.rebases)
+	assert.Equal(t, []reviewStacksPushCall{{path: "/workspace/child", branch: child.HeadRef, forceWithLease: true}}, gitClient.pushes)
+}
+
 func TestRebaseCurrentReviewStack_FailsBeforeRebaseWhenWorktreeDirty(t *testing.T) {
 	restoreClients := stubReviewStacksClients(t)
 	parent, child, _ := reviewStackPullRequests()

--- a/pkg/commands/review_test.go
+++ b/pkg/commands/review_test.go
@@ -83,8 +83,7 @@ func TestDefaultPRTemplate(t *testing.T) {
 	// Verify the default PR template contains expected placeholders
 	assert.Contains(t, defaultPRTemplate, "**Summary**\n\n<!-- fotingo:start summary -->")
 	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:start summary -->")
-	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:start stacked-prs -->")
-	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:end stacked-prs -->")
+	assert.NotContains(t, defaultPRTemplate, "stacked-prs")
 	assert.Contains(t, defaultPRTemplate, "<!-- fotingo:end changes -->")
 	assert.Contains(t, defaultPRTemplate, "**Summary**")
 	assert.NotContains(t, defaultPRTemplate, "{summary}")

--- a/pkg/commands/testdata/help_review_stacks.golden
+++ b/pkg/commands/testdata/help_review_stacks.golden
@@ -6,7 +6,7 @@ Usage:
 
 Available Commands:
   rebase      Rebase local stack branches in order
-  sync        Refresh stacked PR sections across the current stack
+  sync        Refresh native stack state
 
 Flags:
   -h, --help   help for stacks

--- a/pkg/commands/testdata/help_review_stacks_sync.golden
+++ b/pkg/commands/testdata/help_review_stacks_sync.golden
@@ -1,4 +1,4 @@
-Refresh the deterministic stacked PR sections for every open pull request in the current stack.
+Refresh and display the native GitHub pull request stack without editing PR bodies.
 
 Usage:
   fotingo review stacks sync [flags]


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Restore clickable Jira issue links for Atlassian Cloud API roots
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: PR bodies generated from Atlassian Cloud API configurations omitted clickable Jira issue links because the API gateway URL is not a browser URL.

What changed:
- resolve the human-facing Jira site URL from the serverInfo endpoint
- persist the resolved display URL for subsequent clients
- preserve graceful fallback when display metadata is unavailable
- add regression coverage and refresh generated documentation

Testing:
- go test ./...
- pre-commit run -a
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
Fixes [FOTINGO-52](https://tagoro9.atlassian.net/browse/FOTINGO-52)
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix(jira): restore issue links for cloud API roots (+56/-16)
* fix(jira): persist cloud display URL (+27/-16)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)